### PR TITLE
Fix CI failure about VignetteBuilder

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,7 +39,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          # install the package itself as we register vignette engine
+          extra-packages: any::rcmdcheck, local::.
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2


### PR DESCRIPTION
Looking at Quarto's CI setting, this seems the trick.

https://github.com/quarto-dev/quarto-r/blob/c0d6704fd934694da545d7145416d07e1a45fec1/.github/workflows/R-CMD-check.yaml#L68-L69