### PR TITLE
Install X11 on macOS runner to test cairo_pdf device

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies for cairo_pdf device
         if: runner.os == 'macOS'
         run: |
-          brew --cask install xquartz
+          brew install --cask xquartz
 
       - uses: r-lib/actions/check-r-package@v2
         with:


### PR DESCRIPTION
I downloaded and checked the `litedown-Ex.Rout` in [the artifact of the failed run](https://github.com/yihui/litedown/actions/runs/9175518436). I found a warning which indicates X11 is not installed. I'm not sure if there's more lightweight solution, but I hope this makes the CI pass...

```
> fuse(doc, ".tex")
Warning in grSoftVersion() :
  unable to load shared object '/Library/Frameworks/R.framework/Resources/modules//R_X11.so':
  dlopen(/Library/Frameworks/R.framework/Resources/modules//R_X11.so, 0x0006): Library not loaded: /opt/X11/lib/libSM.6.dylib
  Referenced from: <9A3F5E83-2A35-33C3-9C5A-5255B116A1BE> /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/modules/R_X11.so
  Reason: tried: '/opt/X11/lib/libSM.6.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/X11/lib/libSM.6.dylib' (no such file), '/opt/X11/lib/libSM.6.dylib' (no such file), '/Library/Frameworks/R.framework/Resources/lib/libSM.6.dylib' (no such file), '/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/21.0.3-9.0/arm64/Contents/Home//lib/server/libSM.6.dylib' (no such file), '/Library/Frameworks/R.framework/Resources/lib/libSM.6.dylib' (no such file), '/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/21.0.3-9.0/arm64/Contents/Home//lib/server/libSM.6.dylib' (no such file), '/Library/Frameworks/R.framework/Resources [... truncated]
Warning in cairoVersion() :
  unable to load shared object '/Library/Frameworks/R.framework/Resources/library/grDevices/libs//cairo.so':
  dlopen(/Library/Frameworks/R.framework/Resources/library/grDevices/libs//cairo.so, 0x0006): Library not loaded: /opt/X11/lib/libXrender.1.dylib
  Referenced from: <424B95BA-1CAA-3826-9CA0-7CA4D9FCE242> /Library/Frameworks/R.framework/Versions/4.4-arm64/Resources/library/grDevices/libs/cairo.so
  Reason: tried: '/opt/X11/lib/libXrender.1.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/X11/lib/libXrender.1.dylib' (no such file), '/opt/X11/lib/libXrender.1.dylib' (no such file), '/Library/Frameworks/R.framework/Resources/lib/libXrender.1.dylib' (no such file), '/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/21.0.3-9.0/arm64/Contents/Home//lib/server/libXrender.1.dylib' (no such file), '/Library/Frameworks/R.framework/Resources/lib/libXrender.1.dylib' (no such file), '/Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/21.0.3-9.0/arm64/Contents/Home//lib/ [... truncated]
Warning in (function (filename = if (onefile) "Rplots.pdf" else "Rplot%03d.pdf",  :
  failed to load cairo DLL
```