### PR TITLE
amend #62: collapse string for multiple authors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,9 +3,10 @@ Type: Package
 Title: A Lightweight Version of R Markdown
 Version: 0.4.11
 Authors@R: c(
-   person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666", URL = "https://yihui.org")),
-   person()
-   )
+    person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666", URL = "https://yihui.org")),
+    person("Tim", "Taylor", role = "ctb", comment = c(ORCID = "0000-0002-8587-7113")),
+    person()
+    )
 Description: Render R Markdown to Markdown (without using 'knitr'), and Markdown
     to lightweight HTML or 'LaTeX' documents with the 'commonmark' package (instead
     of 'Pandoc'). Some missing Markdown features in 'commonmark' are also

--- a/R/package.R
+++ b/R/package.R
@@ -170,7 +170,7 @@ pkg_authors = function(desc, role = NULL, extra = TRUE) {
     if (length(link)) name = sprintf('[%s](%s)', name, link)
     one_string(c(name, orcid, role), ' ')
   })
-  a
+  if (length(a) > 1) one_string(a, ', ') else a
 }
 
 #' @param path For [pkg_news()], path to the `NEWS.md` file. If empty, [news()]

--- a/R/package.R
+++ b/R/package.R
@@ -134,7 +134,7 @@ pkg_desc = function(name = detect_pkg()) {
   names(d) = fields
   # remove single quotes on words (which are unnecessary IMO)
   for (i in c('Title', 'Description')) d[[i]] = sans_sq(d[[i]])
-  d[['Author']] = pkg_authors(d)
+  d[['Author']] = one_string(pkg_authors(d), ', ')
   d[['Authors@R']] = NULL
   # convert URLs to <a>, and escape HTML in other fields
   for (i in names(d)) d[[i]] = if (!is.na(d[[i]])) {
@@ -170,7 +170,7 @@ pkg_authors = function(desc, role = NULL, extra = TRUE) {
     if (length(link)) name = sprintf('[%s](%s)', name, link)
     one_string(c(name, orcid, role), ' ')
   })
-  if (length(a) > 1) one_string(a, ', ') else a
+  a
 }
 
 #' @param path For [pkg_news()], path to the `NEWS.md` file. If empty, [news()]

--- a/man/litedown-package.Rd
+++ b/man/litedown-package.Rd
@@ -23,4 +23,9 @@ Useful links:
 \author{
 \strong{Maintainer}: Yihui Xie \email{xie@yihui.name} (\href{https://orcid.org/0000-0003-0645-5666}{ORCID}) (https://yihui.org)
 
+Other contributors:
+\itemize{
+  \item Tim Taylor (\href{https://orcid.org/0000-0002-8587-7113}{ORCID}) [contributor]
+}
+
 }


### PR DESCRIPTION
In tweaking #62 we lost the collapsing of the character vector for multiple authors which causes a later [`is.na()` call](https://github.com/yihui/litedown/blob/b2def46b8d2011cb3cec4216efa56fe1362a504e/R/package.R#L140) to error. 

This fixes that.
