### PR TITLE
feat: allow filtering of 'internal' Rd

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -301,7 +301,7 @@ tweak_citation = function(x) {
 #' @export
 pkg_manual = function(
   name = detect_pkg(), toc = TRUE, number_sections = TRUE, overview = TRUE,
-  examples = list()
+  examples = list(), internal = TRUE
 ) {
   links = tools::findHTMLlinks('')
   # resolve internal links (will assign IDs of the form sec:man-ID to all h2)
@@ -314,8 +314,14 @@ pkg_manual = function(
 
   db = tools::Rd_db(name)  # all Rd pages
   intro = paste0(name, '-package.Rd')  # the name-package entry (package overview)
-  entries = setdiff(names(db), intro)
+  if (isFALSE(internal)) {
+    idx = uapply(db, function(x) isTRUE(tools:::.Rd_get_metadata(x, "keyword") == "internal"))
+    entries = setdiff(names(db), names(db[idx]))
+  } else {
+    entries = setdiff(names(db), intro)
+  }
   db = db[c(if (overview && intro %in% names(db)) intro, entries)]
+
   al = lapply(db, Rd_aliases)
 
   cl = header_class(toc, number_sections, FALSE)


### PR DESCRIPTION
Hi @yihui, re: #78 

I'm experimenting with the following locally. I've marked as draft as currently I'm using the internal `tools:::.Rd_get_metadata()` function and I suspect you will have a prefered approach there anyway.

I've kept the default argument as `internal = TRUE` for backwards compatibility but I think it would actually be better defaulting to `FALSE`.

Mainly flagging for you as a proof of concept.

Cheers

