### PR TITLE
Changes to support htmlwidgets integration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: litedown
 Type: Package
 Title: A Lightweight Version of R Markdown
-Version: 0.7
+Version: 0.7.1
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666", URL = "https://yihui.org")),
     person("Tim", "Taylor", role = "ctb", comment = c(ORCID = "0000-0002-8587-7113")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# CHANGES IN litedown VERSION 0.7
+# CHANGES IN litedown VERSION 0.7.1
 
 - `pkg_manual()` will exclude help pages with the keyword `internal` (thanks, @TimTaylor, #78).
 
@@ -11,6 +11,10 @@
 - Fixed a bug that inline code expressions (`` `{lang} expr` ``) cannot be correctly located when the line has leading spaces that are not meaningful.
 
 - Deleted vignettes `markdown-examples` and `markdown-output`. They are rendered on the package site now: https://git.yihui.org/litedown/examples/test-options.html
+
+- Allows absolute paths in filename dependencies in `vest()`.
+
+- Allows `meta` to be specified in chunk options.
 
 # CHANGES IN litedown VERSION 0.6
 

--- a/R/mark.R
+++ b/R/mark.R
@@ -78,6 +78,7 @@ mark = function(input, output = NULL, text = NULL, options = NULL, meta = list()
     yaml[intersect(names(yaml), top_meta)],
     yaml_field(yaml, format),
     list(generator = I(paste('litedown', packageVersion('litedown')))),
+    reactor("meta"),
     meta
   )
   meta = normalize_meta(meta)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1289,6 +1289,7 @@ gen_tag = function(
   } else stop("The file extension '", ext, "' is not supported.")
   is_web = is_https(x)
   is_rel = !is_web && is_rel_path(x)
+  is_abs = !is_web && is_abs_path(x)
   if (is_web && embed_https && xfun::url_filename(x) == 'MathJax.js') {
     warning('MathJax.js cannot be embedded. Please use MathJax v3 instead.')
     embed_https = FALSE
@@ -1302,6 +1303,8 @@ gen_tag = function(
       x, offline, handler = function(code) resolve_url(x, code, ext, FALSE)
     )
     sprintf(t1, x)
+  } else if (is_abs) {
+    one_string(c(t2[1], read_utf8(x), t2[2]))
   } else {
     # embedding for other cases
     one_string(c(t2[1], resolve_external(x, is_web, ext), t2[2]))


### PR DESCRIPTION
This PR changes two things:

1.  It changes `mark()` to allow `meta` to be specified as a chunk option.  This will allow an htmlwidget `record_print()` method to insert dependencies.

I considered some other ways to do this:
   a. Use the `litedown.html.meta` option.  The problem with this is that there doesn't seem to be a way to restore that option at the end of the run, whereas `fuse()` does restore `reactor()` values.
  b. Add a new function that code could use to set options.  This seems unnecessarily complicated.
  c. Use Javascript methods directly.  The problem with this is that some dependencies could end up inserted multiple times.

2.  It changes `gen_tag()` so that a file dependency can be specified as an absolute path.  That's how `htmltools::resolveDependencies()` will produce them.  

 It would be possible to convert those absolute paths to relative paths, but that seems kludgy.

This code works with the `litedown` branch of https://github.com/dmurdoch/htmlwidgets .
