### PR TITLE
Fix for #88

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: litedown
 Type: Package
 Title: A Lightweight Version of R Markdown
-Version: 0.7.2
+Version: 0.7.3
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666", URL = "https://yihui.org")),
     person("Tim", "Taylor", role = "ctb", comment = c(ORCID = "0000-0002-8587-7113")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - `fuse(text = '# text')` will be treated as Markdown input instead of R code input (thanks, @chuxinyuan, #102).
 
+- Fixed the bug that the chunk option `fig.path` does not work when it does not contain `/` (thanks, @J-Moravec, #88).
+
 # CHANGES IN litedown VERSION 0.7
 
 - `pkg_manual()` will exclude help pages with the keyword `internal` (thanks, @TimTaylor, #78).

--- a/R/fuse.R
+++ b/R/fuse.R
@@ -749,6 +749,7 @@ fuse_code = function(x, blocks) {
     sub('^[.]/', '.', paste0(dirname(relative_path(p3[1], .env$wd_out)), '/')),
     error = function(e) NULL
   )
+  fig.dir[fig.dir == "."] = ""
 
   # record plot paths so they can be cleaned up if option embed_cleanup = true;
   # however, when cache = true, we shouldn't clean up plots since they won't be

--- a/R/fuse.R
+++ b/R/fuse.R
@@ -746,10 +746,9 @@ fuse_code = function(x, blocks) {
   p3 = unlist(p2)  # vector of plot paths
   # get the relative path of the plot directory
   fig.dir = if (length(p3)) tryCatch(
-    sub('^[.]/', '.', paste0(dirname(relative_path(p3[1], .env$wd_out)), '/')),
+    sub('^[.]/', '', paste0(dirname(relative_path(p3[1], .env$wd_out)), '/')),
     error = function(e) NULL
   )
-  fig.dir[fig.dir == "."] = ""
 
   # record plot paths so they can be cleaned up if option embed_cleanup = true;
   # however, when cache = true, we shouldn't clean up plots since they won't be

--- a/tests/fig_path.R
+++ b/tests/fig_path.R
@@ -13,12 +13,12 @@ plot(1)
 
 old = litedown::reactor(fig.path = 'foo')
 out = litedown::fuse(text = src, output = 'markdown')
-stopifnot('![](<foochunk-1-1.png>' %in% strsplit(out, '\n')[[1]])
+stopifnot('![](<foochunk-1-1.png>)' %in% unlist(strsplit(out, '\n')))
 unlink('foochunk-1-1.png')
 
 litedown::reactor(fig.path = 'foo/bar')
 out = litedown::fuse(text = src, output = 'markdown')
-stopifnot('![](<foo/barchunk-1-1.png>)' %in% strsplit(out, '\n')[[1]])
+stopifnot('![](<foo/barchunk-1-1.png>)' %in% unlist(strsplit(out, '\n')))
 unlink('foo', recursive = TRUE)
 
 litedown::reactor(old)

--- a/tests/fig_path.R
+++ b/tests/fig_path.R
@@ -1,18 +1,24 @@
-local({
-    opts = options("litedown.html.options" = list("embed_resources" = FALSE))
-    on.exit(options(opts), add = TRUE)
+src = '
+---
+output:
+  html:
+    options:
+      embed_resources: false
+---
 
-    react = litedown::reactor(fig.path = "foo")
-    on.exit(litedown::reactor(react), add = TRUE)
+```{r}
+plot(1)
+```
+'
 
-    text = litedown::fuse(text = "```{r}\nplot(1)\n```", output = "markdown")
-    link = strsplit(text, "\n")[[1]][4]
-    stopifnot(identical("![](<foochunk-1-1.png>)", link))
-    unlink("foochunk-1-1.png")
+old = litedown::reactor(fig.path = 'foo')
+out = litedown::fuse(text = src, output = 'markdown')
+stopifnot('![](<foochunk-1-1.png>' %in% strsplit(out, '\n')[[1]])
+unlink('foochunk-1-1.png')
 
-    litedown::reactor(fig.path = "foo/bar")
-    text = litedown::fuse(text = "```{r}\nplot(1)\n```", output = "markdown")
-    link = strsplit(text, "\n")[[1]][4]
-    stopifnot(identical("![](<foo/barchunk-1-1.png>)", link))
-    unlink("foo", recursive = TRUE)
-})
+litedown::reactor(fig.path = 'foo/bar')
+out = litedown::fuse(text = src, output = 'markdown')
+stopifnot('![](<foo/barchunk-1-1.png>)' %in% strsplit(out, '\n')[[1]])
+unlink('foo', recursive = TRUE)
+
+litedown::reactor(old)

--- a/tests/fig_path.R
+++ b/tests/fig_path.R
@@ -1,0 +1,18 @@
+local({
+    opts = options("litedown.html.options" = list("embed_resources" = FALSE))
+    on.exit(options(opts), add = TRUE)
+
+    react = litedown::reactor(fig.path = "foo")
+    on.exit(litedown::reactor(react), add = TRUE)
+
+    text = litedown::fuse(text = "```{r}\nplot(1)\n```", output = "markdown")
+    link = strsplit(text, "\n")[[1]][4]
+    stopifnot(identical("![](<foochunk-1-1.png>)", link))
+    unlink("foochunk-1-1.png")
+
+    litedown::reactor(fig.path = "foo/bar")
+    text = litedown::fuse(text = "```{r}\nplot(1)\n```", output = "markdown")
+    link = strsplit(text, "\n")[[1]][4]
+    stopifnot(identical("![](<foo/barchunk-1-1.png>)", link))
+    unlink("foo", recursive = TRUE)
+})


### PR DESCRIPTION
The problem lied deeper in fuse when the relative path "." was retained. This is now replaced in `fuse_code` before it is infused in the constructed link.

Tests included.