### PR TITLE
Split overflowing slide 10 into two slides in example 026

### DIFF
--- a/examples/026-snap-clean.Rmd
+++ b/examples/026-snap-clean.Rmd
@@ -151,28 +151,32 @@ This should interface directly with "manual" markdown tables...
 
 ## Regression tables
 
-### modelsummary
+### Regression example
 
-<!-- install these packages and remove eval = FALSE to render these tables -->
+<!-- install these packages, remove eval = FALSE from the first chunk,
+and uncomment the third slide to render the table -->
 
 ```{r, eval = FALSE}
 library(fixest)
 
 mods = feols(
-  rating ~ complaints + #privileges + 
+  rating ~ complaints +
     learning + csw0(raises + critical),
   data = attitude
 )
 
 dict = c("rating"     = "Overall Rating",
          "complaints" = "Handling of Complaints",
-        #  "privileges" = "No Special Priviledges",
          "learning"   = "Opportunity to Learn",
          "raises"     = "Performance-Based Raises",
          "critical"   = "Too Critical")
 ```
 
-```{r, eval = FALSE}
+## Regression tables
+
+### modelsummary
+
+```{r modelsummary-table, eval = FALSE}
 library(modelsummary)
 
 modelsummary(
@@ -184,6 +188,16 @@ modelsummary(
   tinytable::group_tt(j = list("Dep. variable: Overall Rating" = 2:3)) |>
   tinytable::style_tt(i = 1:2, j = 2:3, background = "pink")
 ```
+
+<!-- Uncomment the following slide to show the regression table -->
+<!--
+## Regression tables
+
+### modelsummary
+
+```{r modelsummary-table, echo = FALSE}
+```
+-->
 
 ## Plots
 

--- a/examples/026-snap-clean.md
+++ b/examples/026-snap-clean.md
@@ -143,26 +143,30 @@ This should interface directly with "manual" markdown tables...
 
 ## Regression tables
 
-### modelsummary
+### Regression example
 
-<!-- install these packages and remove eval = FALSE to render these tables -->
+<!-- install these packages, remove eval = FALSE from the first chunk,
+and uncomment the third slide to render the table -->
 
 ``` {.r}
 library(fixest)
 
 mods = feols(
-  rating ~ complaints + #privileges + 
+  rating ~ complaints +
     learning + csw0(raises + critical),
   data = attitude
 )
 
 dict = c("rating"     = "Overall Rating",
          "complaints" = "Handling of Complaints",
-        #  "privileges" = "No Special Priviledges",
          "learning"   = "Opportunity to Learn",
          "raises"     = "Performance-Based Raises",
          "critical"   = "Too Critical")
 ```
+
+## Regression tables
+
+### modelsummary
 
 ``` {.r}
 library(modelsummary)
@@ -176,6 +180,16 @@ modelsummary(
   tinytable::group_tt(j = list("Dep. variable: Overall Rating" = 2:3)) |>
   tinytable::style_tt(i = 1:2, j = 2:3, background = "pink")
 ```
+
+<!-- Uncomment the following slide to show the regression table -->
+<!--
+## Regression tables
+
+### modelsummary
+
+```{r modelsummary-table, echo = FALSE}
+```
+-->
 
 ## Plots
 


### PR DESCRIPTION
I noticed slide 10 of the clean theme example (026) overflows

<https://pkg.yihui.org/litedown/examples/026-snap-clean>.

This splits it into two slides, with instructions to uncomment the table output on a third slide (if evaluating that code). This matches what happens in the original deck <https://grantmcdermott.com/quarto-revealjs-clean-demo/template.html#/regression-tables-1-output>.