### PR TITLE
Factor out read_desc() to read package metadata without requiring installation

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -130,12 +130,7 @@ pkg_desc = function(name = detect_pkg(), type = c('table', 'dl')) {
     'Title', 'Version', 'Description', 'Depends', 'Imports', 'Suggests',
     'License', 'URL', 'BugReports', 'VignetteBuilder', 'Authors@R', 'Author'
   )
-  # read the DESCRIPTION file if pkg root is found, otherwise use installed info
-  d = if (is.character(p <- attr(name, 'path'))) {
-    as.list(read.dcf(file.path(p, 'DESCRIPTION'))[1, ][fields])
-  } else {
-    packageDescription(name, fields = fields)
-  }
+  d = read_desc(name, fields)
   names(d) = fields
   # remove single quotes on words (which are unnecessary IMO)
   for (i in c('Title', 'Description')) d[[i]] = sans_sq(d[[i]])
@@ -453,6 +448,17 @@ run_examples = function(html, config, path) {
     res = one_string(c('', format(res, 'markdown')))
     res
   })
+}
+
+# read package metadata: from the DESCRIPTION file if the package root is found,
+# otherwise from the installed package
+read_desc = function(name = detect_pkg(), fields = NULL) {
+  if (is.character(p <- attr(name, 'path'))) {
+    d = read.dcf(file.path(p, 'DESCRIPTION'))[1, ]
+    as.list(if (is.null(fields)) d else d[fields])
+  } else {
+    packageDescription(name, fields = fields)
+  }
 }
 
 # detect package name and root path from current and upper dirs


### PR DESCRIPTION
## Summary

Extracts the DESCRIPTION-reading logic in `pkg_desc()` into an internal `read_desc()` helper. It reads the `DESCRIPTION` file from the package root when `detect_pkg()` finds it, and falls back to `packageDescription()` for an installed package otherwise (the same behavior `pkg_desc()` already had).

## Motivation

The website project's `_footer.Rmd` template (in [yihui/actions](https://github.com/yihui/actions)) currently calls `packageDescription(litedown:::detect_pkg())` to show author/version info. That reads the **installed** package's metadata, ignoring the source path that `detect_pkg()` already carries — so rendering the site fails when the package isn't installed:

```
Error in desc[["Authors@R"]] : subscript out of bounds
In packageDescription(litedown:::detect_pkg()) : no package 'marth' was found
Quitting from _footer.Rmd
```

(reported in yihui/actions#15)

With `read_desc()` exposed, the footer can infer metadata straight from `DESCRIPTION` without an install. A follow-up PR in yihui/actions switches the template to `litedown:::read_desc()`.

## Notes

- `pkg_desc()` behavior is unchanged — it now delegates to the helper.
- Internal/unexported, so no NEWS entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)