### PR TITLE
pkg_citation() no longer requires the package to be installed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN litedown VERSION 0.12
 
+- `pkg_citation()` no longer requires the package to be installed. When the package source root is detected, it reads the `CITATION` file (or auto-generates the citation from `DESCRIPTION`) directly, instead of calling `citation()` on the installed package (thanks, @jangorecki, yihui/actions#15).
+
 
 # CHANGES IN litedown VERSION 0.11
 

--- a/R/package.R
+++ b/R/package.R
@@ -290,11 +290,22 @@ github_link = function(path) {
 #' @rdname pkg_desc
 #' @export
 pkg_citation = function(name = detect_pkg()) {
-  res = uapply(citation(name), function(x) {
+  res = uapply(read_citation(name), function(x) {
     x = tweak_citation(x)
     unname(c(format(x, style = 'text'), fenced_block(toBibtex(x), 'latex')))
   })
   new_asis(res)
+}
+
+# get citation info from the source package root if found (so that the package
+# does not need to be installed), otherwise from the installed package
+read_citation = function(name = detect_pkg()) {
+  if (!is.character(p <- attr(name, 'path'))) return(citation(name))
+  meta = read_desc(name)
+  # read the CITATION file if present, otherwise auto-generate from DESCRIPTION
+  f = file.path(p, c('inst/CITATION', 'CITATION'))
+  if (any(i <- file_exists(f))) utils::readCitationFile(f[i][1], meta) else
+    citation(meta$Package, auto = meta)
 }
 
 # dirty hack to add year if missing


### PR DESCRIPTION
## Summary

`pkg_citation()` called `citation(name)`, which reads the **installed** package. When documenting an uninstalled package (e.g. rendering a website in CI), it failed:

```
Error in citation(name) : there is no package called 'marth'
```

This adds an internal `read_citation()` helper, mirroring the recent `read_desc()` change (#137): when `detect_pkg()` finds the package source root, it reads the source `inst/CITATION`/`CITATION` file if present, otherwise auto-generates the citation from `DESCRIPTION` via `citation(auto = meta)`. It falls back to `citation(name)` (installed package) only when no source root is found.

## Testing

Verified all three paths against a temp package root with only a `DESCRIPTION`:
- no CITATION → auto-generated from DESCRIPTION (author + version + URL, year filled by `tweak_citation()`)
- with `inst/CITATION` → reads the custom citation
- no source root → falls back to `citation(name)` for the installed package

Reported in yihui/actions#15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)