### PR TITLE
Fix multi-backtick inline code losing fences on indented lines

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: litedown
 Type: Package
 Title: A Lightweight Version of R Markdown
-Version: 0.11.1
+Version: 0.11.2
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666", URL = "https://yihui.org")),
     person("Tim", "Taylor", role = "ctb", comment = c(ORCID = "0000-0002-8587-7113")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN litedown VERSION 0.12
 
+- Fixed a bug that a multi-backtick inline code expression (e.g., ``` `` `{r} code` `` ```) on an indented line (such as a continuation line of a list item) left its fences and padding spaces in the output (#132).
+
 
 # CHANGES IN litedown VERSION 0.11
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 # CHANGES IN litedown VERSION 0.12
 
-- Fixed a bug that a multi-backtick inline code expression (e.g., ``` `` `{r} code` `` ```) on an indented line (such as a continuation line of a list item) left its fences and padding spaces in the output (#132).
-
+- Fixed a bug that a multi-backtick inline code expression (e.g., ``` `` `{r} code` `` ```) on an indented line (such as a continuation line of a list item) left its fences and padding spaces in the output (#139).
 
 # CHANGES IN litedown VERSION 0.11
 

--- a/R/fuse.R
+++ b/R/fuse.R
@@ -175,12 +175,13 @@ crack = function(input, text = NULL) {
       p = rbind(p[1, ] - 1, p[2, ] + 1)
       p = matrix(c(1, p, nchar(x)), nrow = 2)
       x2 = substring(x, p[1, ], p[2, ])  # text
-      # get rid of left-over backticks
+      # get rid of left-over backticks (and the padding space that a multi-
+      # backtick fence adds around the code, e.g., the spaces in `` `code` ``)
       N = length(x2)
-      x2[1] = gsub('`+$', '', x2[1])  # trailing ` of first
-      x2[N] = gsub('^`+', '', x2[N])  # leading ` of last
+      x2[1] = gsub('`+ ?$', '', x2[1])  # trailing ` of first
+      x2[N] = gsub('^ ?`+', '', x2[N])  # leading ` of last
       # ` at both ends for text in the middle
-      if (N > 2) x2[2:(N - 1)] = gsub('^`+|`+$', '', x2[2:(N - 1)])
+      if (N > 2) x2[2:(N - 1)] = gsub('^ ?`+|`+ ?$', '', x2[2:(N - 1)])
       # see if the code is wrapped in $ $
       d1 = substring(x2, nchar(x2), nchar(x2)) == '$'
       d2 = substring(x2, 1, 1) == '$'

--- a/tests/test-cran/test-crack.R
+++ b/tests/test-cran/test-crack.R
@@ -69,6 +69,21 @@ assert('crack() handles inline code in text blocks', {
   (is.list(res[[1]]$source))
 })
 
+assert('crack() strips fence padding for multi-backtick inline code on indented lines', {
+  # `` `` ``-fences pad code with a space on each side; on an indented line,
+  # commonmark's sourcepos ignores the indentation, so the leftover text used to
+  # keep the fence and its padding space (yihui/litedown#132)
+  src = c('- item', '  `` {r} 1 + 1 `` and `` {r} 2 + 2 `` done')
+  res = crack(text=src)
+  x = res[[1]]$source
+  txt = unlist(x[!vapply(x, is.list, TRUE)])
+  # no leftover backticks in the surrounding text fragments
+  (!any(grepl('`', txt)))
+  # the code fragments are extracted verbatim
+  code = vapply(Filter(is.list, x), `[[`, '', 'source')
+  (code %==% c('1 + 1', '2 + 2'))
+})
+
 assert('crack() supports non-R engines', {
   src = c('```{python}', 'x = 1', '```')
   res = crack(text=src)


### PR DESCRIPTION
## Problem

A multi-backtick inline code expression such as `` `{r} code` `` is padded with a space on each side (per CommonMark). When such an expression sits on an **indented** line — e.g., a continuation line of a list item — the fences leaked into the output:

```md
-   The default CSS assets are
    `` {r} xfun::join_words(x, before = '`') ``.
```

rendered as

```md
-   The default CSS assets are
    `` `@a`, `@b` ``.
```

instead of the intended `` `@a`, `@b` ``.

## Cause

`commonmark::markdown_xml(sourcepos = TRUE)` ignores leading indentation when reporting column positions (already noted in a comment in `crack()`). On an indented line the position-correction path fires and relocates the bare code, leaving `fence + padding-space` in the surrounding text fragments. The leftover-backtick stripping in `crack()` only removed backtick runs (`` `+$ ``, `` ^`+ ``), not the padding space a multi-backtick fence adds around the code, so the fences survived.

Single-backtick inline code is unaffected (no padding space); non-indented multi-backtick code is unaffected (correction path doesn't fire).

## Fix

Also consume the optional padding space adjacent to the fence when stripping leftover backticks.

## Test

Added a regression test in `test-crack.R` (fails before the fix, passes after). Full `test-cran` suite passes; rebuilding all `examples/` produces no output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)