### PR TITLE
Speed up crack() inline code handling

### DIFF
--- a/R/fuse.R
+++ b/R/fuse.R
@@ -174,13 +174,12 @@ crack = function(input, text = NULL) {
       # position of code c(row1, col1, row2, col2)
       pos = matrix(b$pos, nrow = 4)
       x = as.list(head(c(rbind(x2, c(x1, ''))), -1))
+      # split all `{lang} expr` expressions at once (vectorized over x1)
+      zs = match_one(x1, rx_inline)
       for (i in seq_len(N - 1)) {
-        z = match_one(x1[i], rx_inline)[[1]][-1]
+        z = zs[[i]][-1]
         p2 = pos[, i]; save_pos(p2)
-        xi = list(
-          source = z[2], pos = p2,
-          options = csv_options(gsub('^([^,]+)', 'engine="\\1"', z[1]))
-        )
+        xi = list(source = z[2], pos = p2, options = inline_options(z[1]))
         if (dollar[i]) xi$math = TRUE
         x[[2 * i]] = xi
       }
@@ -197,6 +196,15 @@ crack = function(input, text = NULL) {
 # subset all columns of a code-token table (from markdown_code_tokens(), plus
 # the derived `engine` column added in crack()) by a row index/logical vector
 tok_subset = function(d, i) lapply(d, `[`, i)
+
+# parse the `{...}` part of an inline code expression `{lang} expr` into chunk
+# options. The common case is a bare engine name (e.g. `{r}`), which we turn
+# into list(engine = "r") directly; only fall back to the full csv_options()
+# parser when there are actual options (a comma or `=`).
+inline_options = function(x) {
+  if (grepl('^[[:alnum:]_]+$', x)) list(engine = x) else
+    csv_options(sub('^([^,]+)', 'engine="\\1"', x))
+}
 
 set_error_handler = function(input) {
   opts = options(xfun.handle_error.loc_fun = get_loc)


### PR DESCRIPTION
Closes #146. Follow-up to #144/#145.

### Finding

The issue expected fence handling to be the target, but profiling a 6000-line doc (trivial chunk bodies → parsing overhead only) showed the real cost was **per-inline-token** work, dominated by `csv_options()` (~28% of `crack()`), called once per inline expression just to record its engine name — plus a `regexec()` split per token.

Markdown parsing (the C `R_code_tokens` from #144) is a tiny slice; fence handling is minor (chunks are ~5× fewer than inline expressions).

### Changes (inline loop only)

- **`inline_options()`**: the `{...}` of an inline expr is almost always a bare engine name (`{r}`), so build `list(engine = "r")` directly; fall back to full `csv_options()` only when there are real options (a comma or `=`).
- **Vectorized split**: split all `{lang} expr` expressions in one `match_one()` call before the loop, instead of one `regexec()` per token.

### Result

`crack()` ~1.6× faster on large docs:

| doc | main | this PR |
|---|---|---|
| 2404 lines | 348 ms | 210 ms |
| 6004 lines | 812 ms | 520 ms |

No behavior change: full `test-cran` suite passes, all `examples/` render byte-identically, and inline option variants (bare engine / engine+option / engine+numeric) produce identical output. Chunk-header/fence handling left as is.