### PR TITLE
Detect math from rendered output to avoid loading KaTeX/MathJax needlessly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,9 +6,7 @@
 
 - Superscript (`^x^`) and subscript (`~x~`) are now recognized by a 'cmark-gfm' syntax extension (C code under `src/extensions/`) instead of the previous token round-trip in R, and their content is parsed as inline Markdown so nesting works (e.g., `a^b*c*^` gives `a<sup>b<em>c</em></sup>`). Because a single delimiter character can be owned by only one extension, this same extension also provides strikethrough (`~~x~~`); the `superscript`, `subscript`, and `strikethrough` options can still be toggled independently. Matching now follows the same left/right-flanking rules as `*`/`_` emphasis rather than the old restricted character class, which is a small behavior change: a delimiter is recognized only when it "hugs" its content (e.g., `a ^x^ b` still works, but a `^` immediately adjacent to punctuation such as in `a^*b*^` is treated literally). Part of #142.
 
-- Fixed a bug that a math library (KaTeX/MathJax) could be loaded into an HTML page that contains no actual math, e.g., when a `$` appears only in inline code (`` `$x$` ``), as a currency symbol, or when math has been disabled via the `-latex_math` option. The presence of math is now detected from the rendered output rather than the source.
-
-- Fixed a bug in 'cmark-gfm' that inline elements (such as inline code) on indented continuation lines (e.g., wrapped paragraph lines, or lines inside list items or blockquotes) were reported with incorrect source positions (columns). The fix is kept as a patch under `src/patches/` and will be submitted upstream.
+- Fixed a bug in 'cmark-gfm' that inline elements (such as inline code) on indented continuation lines (e.g., wrapped paragraph lines, or lines inside list items or blockquotes) were reported with incorrect source positions (columns). The fix is kept as a patch under `src/patches/`.
 
 - Fixed a bug that a multi-backtick inline code expression (e.g., ``` `` `{r} code` `` ```) on an indented line (such as a continuation line of a list item) left its fences and padding spaces in the output (#139).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - Superscript (`^x^`) and subscript (`~x~`) are now recognized by a 'cmark-gfm' syntax extension (C code under `src/extensions/`) instead of the previous token round-trip in R, and their content is parsed as inline Markdown so nesting works (e.g., `a^b*c*^` gives `a<sup>b<em>c</em></sup>`). Because a single delimiter character can be owned by only one extension, this same extension also provides strikethrough (`~~x~~`); the `superscript`, `subscript`, and `strikethrough` options can still be toggled independently. Matching now follows the same left/right-flanking rules as `*`/`_` emphasis rather than the old restricted character class, which is a small behavior change: a delimiter is recognized only when it "hugs" its content (e.g., `a ^x^ b` still works, but a `^` immediately adjacent to punctuation such as in `a^*b*^` is treated literally). Part of #142.
 
+- Fixed a bug that a math library (KaTeX/MathJax) could be loaded into an HTML page that contains no actual math, e.g., when a `$` appears only in inline code (`` `$x$` ``), as a currency symbol, or when math has been disabled via the `-latex_math` option. The presence of math is now detected from the rendered output rather than the source.
+
 - Fixed a bug in 'cmark-gfm' that inline elements (such as inline code) on indented continuation lines (e.g., wrapped paragraph lines, or lines inside list items or blockquotes) were reported with incorrect source positions (columns). The fix is kept as a patch under `src/patches/` and will be submitted upstream.
 
 - Fixed a bug that a multi-backtick inline code expression (e.g., ``` `` `{r} code` `` ```) on an indented line (such as a continuation line of a list item) left its fences and padding spaces in the output (#139).

--- a/R/mark.R
+++ b/R/mark.R
@@ -135,11 +135,12 @@ mark = function(input, output = NULL, text = NULL, options = NULL, meta = list()
       length(grep(pattern, text, perl = TRUE))
   }
 
-  # LaTeX math ($...$, $$...$$, and \begin{}...\end{} environments) is handled by
-  # the C 'math' extension (enabled above via options$extensions). We only need
-  # to know whether any math is present, to decide whether to load KaTeX/MathJax.
-  has_math = 'math' %in% options$extensions &&
-    length(grep('[$]|\\\\begin\\{', text, perl = TRUE)) > 0
+  # Whether any LaTeX math is present, to decide whether to load KaTeX/MathJax.
+  # We detect this from the *rendered* output (below) rather than the source,
+  # because a bare `$` in the source may just be a dollar sign, inline code
+  # (`$x$`), or math that has been disabled (-latex_math); detecting on the
+  # source would load a math library unnecessarily. See the html branch below.
+  has_math = FALSE
 
   p = NULL  # indices of prose
   find_prose = local({
@@ -261,10 +262,23 @@ mark = function(input, output = NULL, text = NULL, options = NULL, meta = list()
     if (isTRUE(options[['number_sections']])) ret = number_sections(ret)
     # build table of contents
     ret = add_toc(ret, options)
-    # math
-    if (!has_math) has_math = length(ret) && (
-      grepl('$$</p>', ret, fixed = TRUE) || grepl('\\)</span>', ret, fixed = TRUE)
-    )  # math may be from pkg_manual()'s HTML
+    # math: detect the delimiters actually emitted into the output (inline
+    # \(...\), display $$...$$, and \begin{} environments) instead of scanning
+    # the source, which avoids loading a math library for a bare `$`, inline
+    # code (`$x$`), or currency. This is gated on the 'math' extension being
+    # enabled: when math is disabled (-latex_math), $$ / \begin{ in the output
+    # is literal text, not math, and looks identical to real math. pkg_manual()
+    # emits the same delimiters (\(...\), <p>$$...$$</p>) and runs with math
+    # enabled by default, so it is covered too. Code blocks/spans are stripped
+    # first because a math library ignores <code>/<pre> (a literal \( or $$
+    # inside code is not rendered as math, so it must not trigger loading it).
+    if (!has_math && 'math' %in% options$extensions) {
+      r0 = gsub('(?s)<(pre|code)[ >].*?</\\1>', '', ret, perl = TRUE)
+      has_math = length(r0) && (
+        grepl('\\(', r0, fixed = TRUE) || grepl('$$', r0, fixed = TRUE) ||
+        grepl('\\begin{', r0, fixed = TRUE)
+      )
+    }
     is_katex = TRUE
     if (has_math && length(js_math <- js_options(options[['js_math']], 'katex'))) {
       is_katex = js_math$package == 'katex'

--- a/tests/test-cran/test-mark.R
+++ b/tests/test-cran/test-mark.R
@@ -83,6 +83,25 @@ assert('mark() disables math when the latex_math option is off', {
   (mark2('a $x$ b', 'html', options = '-latex_math') %==% '<p>a $x$ b</p>')
 })
 
+assert('mark() loads a math library only when math is actually rendered', {
+  # render a full HTML document (with a template) and check whether KaTeX is
+  # loaded; it should be loaded iff real math ends up in the output
+  has_katex = function(x, options = NULL) {
+    out = mark(I(c('---', 'title: t', '---', '', x)), NA, options = options)
+    any(grepl('katex', out, ignore.case = TRUE))
+  }
+  # real math -> load
+  (has_katex('a $x$ b'))
+  (has_katex(c('d:', '', '$$x + y$$')))
+  (has_katex(c('\\begin{align}', 'a &= b', '\\end{align}')))
+  # false positives that must NOT load a math library
+  (!has_katex('inline code `$x$` here'))       # $ inside inline code
+  (!has_katex('it costs $5 and $6 total'))      # currency
+  (!has_katex(c('```', 'f \\(x)', '```')))      # \( inside a code block
+  (!has_katex(c('`$x$` $x$!', '', '$$x + y$$'), options = '-latex_math'))  # disabled
+  (!has_katex('no math at all'))
+})
+
 assert('mark() renders superscript, subscript, and strikethrough via the C extension', {
   # ^x^ -> <sup>, ~x~ -> <sub>, ~~x~~ -> <del>
   (mark2('H~2~O and E=mc^2^', 'html') %==% '<p>H<sub>2</sub>O and E=mc<sup>2</sup></p>')


### PR DESCRIPTION
Follow-up to the math extension (#151). As noted after the deploy, `has_math` was too loose.

## Problem

`has_math` was computed by grepping the **source** for `$` or `\begin{`:

```r
has_math = 'math' %in% options$extensions &&
  length(grep('[$]|\\\\begin\\{', text, perl = TRUE)) > 0
```

So a `$` that is not math still loaded a math library (KaTeX/MathJax) into the page:
- `$` inside inline code (`` `$x$` ``)
- a currency symbol (`costs $5 and $6`)
- math disabled via `-latex_math` (the `$$`/`\begin{` stays literal in the output)

This is what produced the unnecessary `katex.min.css` / `katex.min.js` on non-math example pages in the site deploy.

## Fix

Now that math is a real node type (the `math` cmark extension), detect it from the **rendered output** instead — the delimiters the extension actually emits: inline `\(...\)`, display `$$...$$`, and `\begin{}` environments. The check is:

- gated on the `math` extension being enabled (with `-latex_math` those delimiters in the output are literal text, not math, and look identical to real math);
- run after stripping `<pre>`/`<code>` regions, because a math library ignores code, so a literal `\(` or `$$` inside a code block must not trigger loading it.

`pkg_manual()` pre-renders `\eqn`/`\deqn` to the same `\(...\)` and `<p>$$...$$</p>` delimiters and runs with math enabled by default, so it stays covered (the previous `$$</p>` / `\)</span>` special cases are subsumed).

## Testing

- New assertion in `test-mark.R` covering both directions: real inline/display/environment math loads KaTeX; `$` in inline code, currency, `\(` in a code block, `-latex_math`, and plain text do not.
- Full `test_pkg("litedown", "test-cran")` passes; re-rendered `examples/` — the affected pages no longer pull in KaTeX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)