### PR TITLE
Render task list checkboxes without disabled="" in cmark

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,6 +6,7 @@ Makefile
 ^LICENSE\.md$
 ^docs$
 ^examples$
+^src/patches$
 ^playground$
 ^site$
 .*\.tar\.gz$

--- a/R/mark.R
+++ b/R/mark.R
@@ -193,8 +193,6 @@ mark = function(input, output = NULL, text = NULL, options = NULL, meta = list()
   has_mermaid = FALSE
 
   if (format == 'html') {
-    # don't disable check boxes
-    ret = gsub('(<li><input type="checkbox" [^>]*?)disabled="" (/>)', '\\1\\2', ret)
     # replace <a> with <span> if href is empty but other attrs exist, so we have
     # a way to create SPANs with attributes, e.g., [text](){.foo} -> <span
     # class="foo"></span>

--- a/src/extensions/tasklist.c
+++ b/src/extensions/tasklist.c
@@ -122,9 +122,9 @@ static void html_render(cmark_syntax_extension *extension,
     cmark_html_render_sourcepos(node, renderer->html, options);
     cmark_strbuf_putc(renderer->html, '>');
     if (node->as.list.checked) {
-      cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" checked=\"\" disabled=\"\" /> ");
+      cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" checked=\"\" /> ");
     } else {
-      cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" disabled=\"\" /> ");
+      cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" /> ");
     }
   } else {
     cmark_strbuf_puts(renderer->html, "</li>\n");

--- a/src/patches/README.md
+++ b/src/patches/README.md
@@ -73,6 +73,9 @@ Current patches (see `apply.sh`):
   opening code fence, so `</p>` followed by a ```` ``` ```` line parses as an
   HTML block plus a separate code block (rather than the fence being absorbed
   into the HTML block). To be submitted upstream to github/cmark-gfm.
+- `tasklist-no-disable.diff` — litedown: render task list checkboxes without the
+  `disabled=""` attribute so they are interactive. litedown-specific (GitHub
+  renders task lists as disabled), not intended for upstream.
 
 Prefer adding new features as standalone files under `src/extensions/` rather
 than as patches to core files: extensions survive upstream syncs untouched,

--- a/src/patches/apply.sh
+++ b/src/patches/apply.sh
@@ -25,3 +25,6 @@ apply inline-sourcepos-cols.diff
 # </p>\n``` is parsed as HTML followed by a code block. To be submitted
 # upstream to github/cmark-gfm.
 apply html-block-code-fence-end.diff
+# Render task list checkboxes without disabled="" (litedown), so they are
+# interactive. litedown-specific (GitHub renders them disabled), not for upstream.
+apply tasklist-no-disable.diff

--- a/src/patches/tasklist-no-disable.diff
+++ b/src/patches/tasklist-no-disable.diff
@@ -1,0 +1,16 @@
+diff --git a/extensions/tasklist.c b/extensions/tasklist.c
+index 7bef454..206c271 100644
+--- a/extensions/tasklist.c
++++ b/extensions/tasklist.c
+@@ -122,9 +122,9 @@ static void html_render(cmark_syntax_extension *extension,
+     cmark_html_render_sourcepos(node, renderer->html, options);
+     cmark_strbuf_putc(renderer->html, '>');
+     if (node->as.list.checked) {
+-      cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" checked=\"\" disabled=\"\" /> ");
++      cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" checked=\"\" /> ");
+     } else {
+-      cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" disabled=\"\" /> ");
++      cmark_strbuf_puts(renderer->html, "<input type=\"checkbox\" /> ");
+     }
+   } else {
+     cmark_strbuf_puts(renderer->html, "</li>\n");

--- a/tests/test-cran/test-render.R
+++ b/tests/test-cran/test-render.R
@@ -54,6 +54,18 @@ assert('markdown_html() still renders correctly', {
   (markdown_html('Hello _World_!\n') %==% '<p>Hello <em>World</em>!</p>\n')
 })
 
+# litedown patches the tasklist extension to render checkboxes without the
+# disabled="" attribute (upstream cmark-gfm emits it), so they are interactive;
+# this replaces a gsub() workaround that used to strip disabled="" in mark()
+assert('task list checkboxes are rendered without disabled=""', {
+  (markdown_html('- [x] a\n- [ ] b\n', extensions = 'tasklist') %==% paste0(
+    '<ul>\n',
+    '<li><input type="checkbox" checked="" /> a</li>\n',
+    '<li><input type="checkbox" /> b</li>\n',
+    '</ul>\n'
+  ))
+})
+
 # a bare closing tag opens a type 6/7 HTML block that, per CommonMark, ends only
 # at a blank line; litedown patches cmark so an opening code fence ends it too,
 # and the fence is parsed as a code block instead of being absorbed as HTML


### PR DESCRIPTION
The tasklist extension in cmark-gfm renders task list items as `<input type="checkbox" disabled="" />` — non-interactive checkboxes, matching how GitHub displays them. litedown wants interactive checkboxes and previously stripped the `disabled=""` attribute with a `gsub()` post-processing step in `mark()`.

This patches the tasklist extension to omit `disabled=""` at render time instead, removing the R workaround. The `checked=""` value is kept because cmark emits XHTML-style self-closing tags (`/>`), where a valueless boolean attribute would be malformed.

The change to the vendored `src/extensions/tasklist.c` (an upstream file that `sync.sh` overwrites) is recorded as `src/patches/tasklist-no-disable.diff` and registered in `apply.sh`. It is litedown-specific (GitHub deliberately renders task lists as disabled), so it is not intended for upstream.

Part of moving `mark()` post-processing from R into the vendored cmark (#142).

Verified: full `test-cran` suite passes (added a regression test), rendered examples are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)