### PR TITLE
Render code block attributes in a cmark extension (part of #142)

### DIFF
--- a/R/mark.R
+++ b/R/mark.R
@@ -163,8 +163,8 @@ mark = function(input, output = NULL, text = NULL, options = NULL, meta = list()
     text[p]
   )
 
-  id4 = id_string(text)
   if (format == 'latex') {
+    id4 = id_string(text)
     # put info string inside code blocks so the info won't be lost, e.g., ```r -> ```\nr;
     # skip raw content blocks (```{=html}/```{=latex}/```{=tex}), whose info
     # string must reach the C 'rawblock' extension intact
@@ -173,9 +173,6 @@ mark = function(input, output = NULL, text = NULL, options = NULL, meta = list()
       text, perl = TRUE
     )
   }
-  # for html, Pandoc-style code block attributes (```{.class #id key="val"}) are
-  # rendered by the C 'attributes' extension, so the info string is passed to
-  # cmark verbatim (no space-hiding / post-render conversion needed here)
 
   # turn @ref into [@ref](#ref) and resolve cross-references later in JS; for
   # latex output, turn @ref to \ref{}

--- a/R/mark.R
+++ b/R/mark.R
@@ -103,6 +103,12 @@ mark = function(input, output = NULL, text = NULL, options = NULL, meta = list()
   # not an optional feature), so it is not exposed as a markdown_options() toggle
   if (format %in% c('html', 'latex'))
     options$extensions = union(options$extensions, 'rawblock')
+  # Pandoc-style code block attributes (```{.class #id key="val"}) are rendered
+  # by the C 'attributes' extension for html output; it only sets an HTML render
+  # func (LaTeX/other formats ignore the info string via cmark's built-in code
+  # rendering, matching the old behavior), and is always on
+  if (format == 'html')
+    options$extensions = union(options$extensions, 'attributes')
 
   # build PDF for LaTeX output when the output file is .pdf or latex_engine is specified
   is_pdf = is_output_file(output) && format == 'latex' &&
@@ -166,16 +172,10 @@ mark = function(input, output = NULL, text = NULL, options = NULL, meta = list()
       '^([> ]*)(```+)(?! *\\{=)([^`].*)$', sprintf('\\1\\2\n\\1%s\\3%s', id4, id4),
       text, perl = TRUE
     )
-  } else if (format == 'html' && length(p) < length(text)) {
-    # hide spaces so that attributes won't be dropped: {.lang foo} -> {.lang!id!foo}
-    r4 = '^([> ]*```+\\s*)(\\{.+})\\s*$'
-    text = match_replace(text, r4, function(x) {
-      x1 = sub(r4, '\\1', x)
-      x2 = sub(r4, '\\2', x)
-      x2 = gsub(' ', id4, x2, fixed = TRUE)
-      paste0(x1, x2)
-    })
   }
+  # for html, Pandoc-style code block attributes (```{.class #id key="val"}) are
+  # rendered by the C 'attributes' extension, so the info string is passed to
+  # cmark verbatim (no space-hiding / post-render conversion needed here)
 
   # turn @ref into [@ref](#ref) and resolve cross-references later in JS; for
   # latex output, turn @ref to \ref{}
@@ -202,18 +202,6 @@ mark = function(input, output = NULL, text = NULL, options = NULL, meta = list()
     if (has_mermaid <- length(grep(r_mmd, ret))) {
       ret = gsub(r_mmd, '<pre class="mermaid">\\1</pre>', ret)
     }
-    r4 = '(<pre><code class="language-)\\{([^"]+)}">'
-    # deal with ```{.class1 .class2 attrs}, which is not supported by commonmark
-    ret = convert_attrs(ret, r4, '\\2', function(r, z, z2) {
-      z1 = sub(r, '\\1', z)
-      # make sure `class` is the first attribute
-      z2 = gsub('^(.+?)( +)(class="[^"]+")(.*)$', '\\3 \\1\\4', z2)
-      i = grepl('^class="', z2)
-      z2 = ifelse(i, sub('^class="', '', z2), paste0('"', z2))
-      paste0(z1, z2, '>')
-    }, 'html', function(z2) gsub(id4, ' ', restore_html(z2)))
-    # some code blocks with "attributes" are verbatim ones
-    ret = match_replace(ret, '```+\\s*\\{.+}', function(x) gsub(id4, ' ', x, fixed = TRUE))
     # remove empty table header
     ret = gsub('<thead>\n<tr>\n(<th[^>]*></th>\n)+</tr>\n</thead>\n', '', ret)
     # table caption: a paragraph that starts with 'Table: ' or ': ' after </table>

--- a/src/Makevars
+++ b/src/Makevars
@@ -11,7 +11,8 @@ LIBCMARK = cmark/cmark.o cmark/node.o cmark/iterator.o cmark/blocks.o cmark/inli
 	cmark/plaintext.o cmark/footnotes.o cmark/map.o \
 	extensions/autolink.o extensions/core-extensions.o extensions/ext_scanners.o \
 	extensions/strikethrough.o extensions/table.o extensions/tagfilter.o extensions/tasklist.o \
-	extensions/math.o extensions/subsup.o extensions/rawblock.o extensions/litedown-extensions.o
+	extensions/math.o extensions/subsup.o extensions/rawblock.o extensions/attributes.o \
+	extensions/litedown-extensions.o
 
 PKG_LIBS = -Lcmark -lstatcmark
 STATLIB = cmark/libstatcmark.a

--- a/src/extensions/attributes.c
+++ b/src/extensions/attributes.c
@@ -1,0 +1,229 @@
+/* Pandoc-style code block attributes extension for litedown.
+ *
+ * Handles fenced code blocks whose info string is a brace-delimited attribute
+ * list, e.g.
+ *
+ *     ```{.r .numberLines #foo style="color: red;"}
+ *     1 + 1
+ *     ```
+ *
+ * and renders it in HTML as
+ *
+ *     <pre><code class="language-r numberLines" id="foo" style="color: red;">
+ *
+ * i.e. `.class` tokens become a single space-separated `class` attribute (each
+ * prefixed with `language-` only for the first one, matching cmark's own
+ * `language-` convention and litedown's previous R output), `#id` becomes an
+ * `id` attribute, `{-}` is shorthand for `.unnumbered`, and `key=value` /
+ * `key="value"` tokens are emitted verbatim as HTML attributes. The class
+ * attribute (if any) is emitted first, then id, then the remaining attributes
+ * in source order, matching the output litedown used to produce by smuggling
+ * the info string past cmark in R (the `id_string()` / `convert_attrs()` dance
+ * in R/mark.R and R/utils.R).
+ *
+ * Only html_render_func is set: for every other output format (latex, xml, man,
+ * commonmark, plaintext) the node falls through to cmark's built-in code-block
+ * rendering, which ignores the info string for those formats. This matches the
+ * old R behavior, where the smuggled attributes were stripped for LaTeX and
+ * never reached the other formats.
+ *
+ * Raw content blocks (`{=html}` / `{=latex}` / `{=tex}`) are owned by the
+ * rawblock extension and are deliberately NOT claimed here (a code block can
+ * carry only one extension); the postprocess pass skips any info string whose
+ * first non-space character after `{` is `=`.
+ *
+ * The extension does not create a new node type: a postprocess pass sets
+ * `node->extension` on the matching CMARK_NODE_CODE_BLOCK nodes so the render
+ * dispatch calls back into this file.
+ *
+ * This is a litedown-only file; it is not part of upstream cmark-gfm and is not
+ * touched by src/patches/sync.sh.
+ */
+
+#include "attributes.h"
+#include <node.h>
+#include <render.h>
+#include <html.h>
+#include <houdini.h>
+#include <string.h>
+
+/* Whether `info` is a brace-delimited attribute list this extension handles,
+ * i.e. `{...}` (after trimming surrounding spaces) that is not a raw content
+ * block `{=...}`. Empty braces `{}` are not claimed (nothing to add). */
+static int is_attr_info(cmark_chunk *info) {
+  const unsigned char *d = info->data;
+  bufsize_t n = info->len;
+  bufsize_t i = 0;
+
+  if (!d)
+    return 0;
+  while (i < n && (d[i] == ' ' || d[i] == '\t'))
+    i++;
+  while (n > i && (d[n - 1] == ' ' || d[n - 1] == '\t'))
+    n--;
+  if (n - i < 2 || d[i] != '{' || d[n - 1] != '}')
+    return 0;
+  if (d[i + 1] == '=')   /* raw content block: owned by the rawblock extension */
+    return 0;
+  return 1;
+}
+
+/* Locate the attribute-list body (the text between the outer braces), trimming
+ * surrounding spaces on the whole info string first. Sets *start/*end to the
+ * byte range [start, end) of the body. Assumes is_attr_info() returned true. */
+static void attr_body(cmark_chunk *info, bufsize_t *start, bufsize_t *end) {
+  const unsigned char *d = info->data;
+  bufsize_t n = info->len, i = 0;
+
+  while (i < n && (d[i] == ' ' || d[i] == '\t'))
+    i++;
+  while (n > i && (d[n - 1] == ' ' || d[n - 1] == '\t'))
+    n--;
+  *start = i + 1;   /* skip '{' */
+  *end = n - 1;     /* index of closing '}' */
+}
+
+/* Emit a class/id token value, HTML-escaping it (matching cmark's own
+ * escape_html for the language class). */
+static void put_value(cmark_strbuf *html, const unsigned char *s, bufsize_t len) {
+  houdini_escape_html0(html, s, len, 0);
+}
+
+/* Render func: build the opening <pre><code ...> tag from the attribute list,
+ * then the (escaped) code body, then the closing tags. */
+static void html_render(cmark_syntax_extension *extension,
+                        cmark_html_renderer *renderer, cmark_node *node,
+                        cmark_event_type ev_type, int options) {
+  cmark_strbuf *html = renderer->html;
+  cmark_chunk *info = &node->as.code.info;
+  cmark_chunk *lit = &node->as.code.literal;
+  const unsigned char *d = info->data;
+  bufsize_t start, end, i;
+  int n_class = 0, have_id = 0;
+  /* buffer for the remaining (key=value) attributes, emitted after class/id */
+  cmark_strbuf rest = CMARK_BUF_INIT(renderer->html->mem);
+  (void)extension;
+
+  if (ev_type != CMARK_EVENT_ENTER)
+    return;
+
+  attr_body(info, &start, &end);
+
+  cmark_html_render_cr(html);
+  cmark_strbuf_puts(html, "<pre");
+  cmark_html_render_sourcepos(node, html, options);
+  cmark_strbuf_puts(html, "><code");
+
+  /* First pass: emit the class attribute, collecting all .class tokens (and the
+   * {-} / .unnumbered shorthand). We scan the whole body, skipping non-class
+   * tokens, so classes always come first regardless of source order. */
+  i = start;
+  while (i < end) {
+    bufsize_t tok, tend;
+    /* skip spaces */
+    while (i < end && (d[i] == ' ' || d[i] == '\t'))
+      i++;
+    if (i >= end)
+      break;
+    tok = i;
+    /* a token runs to the next space, but a quoted value may contain spaces */
+    while (i < end && d[i] != ' ' && d[i] != '\t') {
+      if (d[i] == '"') {
+        i++;
+        while (i < end && d[i] != '"')
+          i++;
+      }
+      i++;
+    }
+    tend = i;
+    if (d[tok] == '.' && tend - tok > 1) {
+      if (n_class == 0)
+        cmark_strbuf_puts(html, " class=\"language-");
+      else
+        cmark_strbuf_putc(html, ' ');
+      put_value(html, d + tok + 1, tend - tok - 1);
+      n_class++;
+    } else if (d[tok] == '-' && tend - tok == 1) {
+      /* {-} is shorthand for .unnumbered */
+      if (n_class == 0)
+        cmark_strbuf_puts(html, " class=\"language-");
+      else
+        cmark_strbuf_putc(html, ' ');
+      cmark_strbuf_puts(html, "unnumbered");
+      n_class++;
+    }
+  }
+  if (n_class > 0)
+    cmark_strbuf_putc(html, '"');
+
+  /* Second pass: id (#id, first one wins) and remaining key=value attributes,
+   * in source order, buffered in `rest`. */
+  i = start;
+  while (i < end) {
+    bufsize_t tok, tend;
+    while (i < end && (d[i] == ' ' || d[i] == '\t'))
+      i++;
+    if (i >= end)
+      break;
+    tok = i;
+    while (i < end && d[i] != ' ' && d[i] != '\t') {
+      if (d[i] == '"') {
+        i++;
+        while (i < end && d[i] != '"')
+          i++;
+      }
+      i++;
+    }
+    tend = i;
+    if (d[tok] == '#' && tend - tok > 1) {
+      if (!have_id) {
+        cmark_strbuf_puts(html, " id=\"");
+        put_value(html, d + tok + 1, tend - tok - 1);
+        cmark_strbuf_putc(html, '"');
+        have_id = 1;
+      }
+    } else if (d[tok] != '.' && !(d[tok] == '-' && tend - tok == 1)) {
+      /* a key=value (or bare key) attribute: emit verbatim, space-separated */
+      cmark_strbuf_putc(&rest, ' ');
+      cmark_strbuf_put(&rest, d + tok, tend - tok);
+    }
+  }
+  cmark_strbuf_put(html, rest.ptr, rest.size);
+  cmark_strbuf_free(&rest);
+
+  cmark_strbuf_putc(html, '>');
+  houdini_escape_html0(html, lit->data, lit->len, 0);
+  cmark_strbuf_puts(html, "</code></pre>\n");
+}
+
+/* Set node->extension on every code block whose info string is an attribute
+ * list, so the render dispatch routes it here. */
+static cmark_node *postprocess(cmark_syntax_extension *self, cmark_parser *parser,
+                               cmark_node *root) {
+  cmark_iter *iter = cmark_iter_new(root);
+  cmark_event_type ev;
+  (void)parser;
+
+  while ((ev = cmark_iter_next(iter)) != CMARK_EVENT_DONE) {
+    cmark_node *node = cmark_iter_get_node(iter);
+    if (ev != CMARK_EVENT_ENTER || node->type != CMARK_NODE_CODE_BLOCK)
+      continue;
+    /* skip blocks already claimed by another extension (e.g. rawblock) */
+    if (node->extension)
+      continue;
+    if (is_attr_info(&node->as.code.info))
+      cmark_node_set_syntax_extension(node, self);
+  }
+
+  cmark_iter_free(iter);
+  return root;
+}
+
+cmark_syntax_extension *create_attributes_extension(void) {
+  cmark_syntax_extension *ext = cmark_syntax_extension_new("attributes");
+
+  cmark_syntax_extension_set_html_render_func(ext, html_render);
+  cmark_syntax_extension_set_postprocess_func(ext, postprocess);
+
+  return ext;
+}

--- a/src/extensions/attributes.h
+++ b/src/extensions/attributes.h
@@ -1,0 +1,8 @@
+#ifndef LITEDOWN_ATTRIBUTES_H
+#define LITEDOWN_ATTRIBUTES_H
+
+#include "cmark-gfm-core-extensions.h"
+
+cmark_syntax_extension *create_attributes_extension(void);
+
+#endif

--- a/src/extensions/litedown-extensions.c
+++ b/src/extensions/litedown-extensions.c
@@ -9,6 +9,7 @@
 #include "math.h"
 #include "subsup.h"
 #include "rawblock.h"
+#include "attributes.h"
 #include "registry.h"
 #include "plugin.h"
 #include "parser.h"
@@ -20,6 +21,7 @@ static int litedown_extensions_registration(cmark_plugin *plugin) {
   cmark_plugin_register_syntax_extension(plugin, create_superscript_extension());
   cmark_plugin_register_syntax_extension(plugin, create_subscript_extension());
   cmark_plugin_register_syntax_extension(plugin, create_rawblock_extension());
+  cmark_plugin_register_syntax_extension(plugin, create_attributes_extension());
   return 1;
 }
 

--- a/src/patches/README.md
+++ b/src/patches/README.md
@@ -37,6 +37,12 @@ overwrite them with upstream `src/` files:
   set in `wrapper.c` / `parse.c` through `litedown_attach_extension()`. The
   upstream `strikethrough` extension is therefore never attached. Written for
   litedown.
+- `src/extensions/attributes.c` / `.h` — Pandoc-style code block attributes
+  extension (```` ```{.class #id key="val"} ````): a postprocess pass tags the
+  matching code blocks and its HTML render func emits the attributes on
+  `<pre><code>` (`.class` → `class`, `#id` → `id`, `{-}` → `.unnumbered`,
+  `key=value` verbatim). Only the HTML render func is set, so other output
+  formats keep cmark's built-in code-block rendering. Written for litedown.
 - `src/extensions/rawblock.c` / `.h` — raw content block extension
   (```` ```{=html} ````, ```` ```{=latex} ````, ```` ```{=tex} ````): a
   postprocess pass tags the matching code blocks with the extension so its

--- a/tests/test-cran/test-render.R
+++ b/tests/test-cran/test-render.R
@@ -54,6 +54,34 @@ assert('markdown_html() still renders correctly', {
   (markdown_html('Hello _World_!\n') %==% '<p>Hello <em>World</em>!</p>\n')
 })
 
+# the 'attributes' extension renders Pandoc-style code block attributes
+# (```{.class #id key="val"}) as HTML attributes on <pre><code>, replacing the
+# id_string()/convert_attrs() smuggling that mark() used to do in R
+assert('the attributes extension renders code block attributes', {
+  cb = function(x) markdown_html(x, extensions = 'attributes')
+  # a single class becomes the language- class (same as a plain info string)
+  (cb('```{.r}\n1\n```\n') %==% '<pre><code class="language-r">1\n</code></pre>\n')
+  # multiple classes are space-joined; #id and key="val" follow class, in order
+  (cb('```{.r .js #foo style="color: red;"}\n1\n```\n') %==% paste0(
+    '<pre><code class="language-r js" id="foo" style="color: red;">1\n',
+    '</code></pre>\n'
+  ))
+  # {-} is shorthand for .unnumbered
+  (cb('```{-}\n1\n```\n') %==% '<pre><code class="language-unnumbered">1\n</code></pre>\n')
+  # an id with no class emits no class attribute (no empty language- class)
+  (cb('```{#foo}\n1\n```\n') %==% '<pre><code id="foo">1\n</code></pre>\n')
+  # class/id values are HTML-escaped (matching cmark's language class escaping)
+  (cb('```{.a<b #c>d}\n1\n```\n') %==%
+     '<pre><code class="language-a&lt;b" id="c&gt;d">1\n</code></pre>\n')
+  # key=value attributes are emitted verbatim (as the old R path did; litedown
+  # runs cmark in UNSAFE mode and treats the input as trusted)
+  (cb('```{style="width: 50%"}\n1\n```\n') %==%
+     '<pre><code style="width: 50%">1\n</code></pre>\n')
+  # a raw content block ({=...}) is left to the rawblock extension, not claimed
+  (markdown_html('```{=html}\n<hr>\n```\n', extensions = c('rawblock', 'attributes')) %==%
+     '<hr>\n')
+})
+
 # litedown patches the tasklist extension to render checkboxes without the
 # disabled="" attribute (upstream cmark-gfm emits it), so they are interactive;
 # this replaces a gsub() workaround that used to strip disabled="" in mark()


### PR DESCRIPTION
Pandoc-style fenced code block attributes, e.g.

````
```{.r .numberLines #foo style="color: red;"}
````

were previously handled entirely in R: `mark()` smuggled the info string past cmark (which splits it at the first space and keeps only the first word as the language) by replacing spaces with a random `id_string()`, then reparsed the mangled `class="language-{...}"` back into real HTML attributes with `convert_attrs()` after rendering. That round-trip was fragile and coupled to a random sentinel.

This adds an `attributes` cmark extension (`src/extensions/attributes.c`) that renders such code blocks directly:

- a postprocess pass tags every code block whose info string is a brace list (but not a `{=...}` raw block, which the `rawblock` extension owns);
- the HTML render func emits the attributes on `<pre><code>`: `.class` tokens are space-joined into a single class (first one prefixed `language-`, matching cmark), `#id` becomes `id`, `{-}` is shorthand for `.unnumbered`, and `key=value` tokens are emitted verbatim, in the order class, id, rest.

Only the HTML render func is set, so LaTeX and the other output formats keep cmark's built-in code-block rendering, matching previous behavior (attributes were stripped for LaTeX and never reached the other formats).

This removes the `id_string()` space-hiding and the post-render `convert_attrs()` pass for HTML in `mark()`. The LaTeX `id4` smuggling (a separate mechanism for preserving info strings inside `\begin{verbatim}`) is unchanged.

A latent bug is fixed as a side effect: an id-only block `` ```{#foo} `` used to render as `class="language-"id="foo"` (empty class, missing space); it now renders as `<pre><code id="foo">` with no class attribute.

Verified: full `test-cran` suite passes (new regression tests in `test-render.R`), and the rendered examples are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)