### PR TITLE
Share one attribute builder between C and R convert_attrs()

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -73,6 +73,7 @@ importFrom(xfun,
   write_utf8
 )
 useDynLib(litedown,R_code_tokens)
+useDynLib(litedown,R_convert_attrs)
 useDynLib(litedown,R_list_extensions)
 useDynLib(litedown,R_parse_markdown)
 useDynLib(litedown,R_prose_lines)

--- a/R/render.R
+++ b/R/render.R
@@ -2,7 +2,7 @@
 # 'commonmark' package (from which the C code and R wrappers are derived) so
 # that litedown can call them internally without depending on 'commonmark'.
 
-#' @useDynLib litedown R_list_extensions R_render_markdown R_parse_markdown R_code_tokens R_prose_lines
+#' @useDynLib litedown R_list_extensions R_render_markdown R_parse_markdown R_code_tokens R_prose_lines R_convert_attrs
 NULL
 
 markdown_html = function(

--- a/R/utils.R
+++ b/R/utils.R
@@ -759,7 +759,6 @@ move_attrs = function(x, format = 'html') {
 }
 
 convert_attrs = function(x, r, s, f, format = 'html', f2 = identity) {
-  r2 = '(?<=^| )[.#]([-:[:alnum:]]+)(?= |$)'  # should we allow other chars in ID/class?
   match_replace(x, r, function(y) {
     z = sub(r, s, y, perl = TRUE)
     if (format == 'html') {
@@ -770,26 +769,11 @@ convert_attrs = function(x, r, s, f, format = 'html', f2 = identity) {
       z = gsub('\\\\([#%])', '\\1', z)
     }
     z2 = f2(z)
-    # {-} is a shorthand of {.unnumbered}
-    z2[z2 == '-'] = '.unnumbered'
-    # convert #id to id="" and .class to class=""
-    z2 = match_replace(z2, r2, function(a) {
-      i = grep('^[.]', a)
-      if ((n <- length(i))) {
-        # merge multiple classes into one class attribute
-        a[i] = sub('^[.]', '', a[i])
-        a[i] = c(sprintf('class="%s"', paste(a[i], collapse = ' ')), rep('', n - 1))
-        a = c(a[i], a[-i])
-      }
-      if (length(i <- grep('^#', a))) {
-        a[i] = gsub(r2, 'id="\\1"', a[i], perl = TRUE)
-        a = c(a[i], a[-i])  # make sure id is the first attribute
-      }
-      a
-    })
-    # remove spaces after class="..." (caused by merging multiple classes)
-    z2 = sub('(^| )(class="[^"]+")  +', '\\1\\2 ', z2)
-    f(r, y, str_trim(z2))
+    # build the HTML attribute string in C (shared with the code block
+    # 'attributes' extension): .class -> class="", #id -> id="", {-} ->
+    # .unnumbered, key=value verbatim, in the order class, id, then the rest
+    z2 = .Call(R_convert_attrs, z2, '')
+    f(r, y, z2)
   })
 }
 

--- a/examples/test-options.md
+++ b/examples/test-options.md
@@ -348,7 +348,7 @@ mark('::: {.foo .bar #baz style="color: red;"}\nasdf\n:::')
 `````
 
 ````` {.html .plain}
-<div id="baz" class="foo bar" style="color: red;">
+<div class="foo bar" id="baz" style="color: red;">
 <p>asdf</p>
 </div>
 `````
@@ -694,7 +694,7 @@ mark('::: foo\nasdf\n:::')
 ````` {.r}
 mark('::: {.foo .bar #baz style="color: red;"}\nasdf\n:::')
 `````
-<div id="baz" class="foo bar" style="color: red;">
+<div class="foo bar" id="baz" style="color: red;">
 <p>asdf</p>
 </div>
 

--- a/src/extensions/attributes.c
+++ b/src/extensions/attributes.c
@@ -83,10 +83,94 @@ static void attr_body(cmark_chunk *info, bufsize_t *start, bufsize_t *end) {
   *end = n - 1;     /* index of closing '}' */
 }
 
-/* Emit a class/id token value, HTML-escaping it (matching cmark's own
- * escape_html for the language class). */
-static void put_value(cmark_strbuf *html, const unsigned char *s, bufsize_t len) {
-  houdini_escape_html0(html, s, len, 0);
+/* Advance past one whitespace-separated token in d[*i, len), treating a
+ * double-quoted run as part of the token (so a quoted value may contain
+ * spaces). On return *tok/*tend bound the token and *i points past it; returns
+ * 0 when no token remains. */
+static int next_token(const unsigned char *d, bufsize_t len, bufsize_t *i,
+                      bufsize_t *tok, bufsize_t *tend) {
+  bufsize_t k = *i;
+  while (k < len && (d[k] == ' ' || d[k] == '\t'))
+    k++;
+  if (k >= len)
+    return 0;
+  *tok = k;
+  while (k < len && d[k] != ' ' && d[k] != '\t') {
+    if (d[k] == '"') {
+      k++;
+      while (k < len && d[k] != '"')
+        k++;
+    }
+    k++;
+  }
+  *tend = k;
+  *i = k;
+  return 1;
+}
+
+/* Build an HTML attribute string from a Pandoc-style attribute list body
+ * d[0, len) (the text inside the braces, e.g. `.r .js #foo k="v"`), appending
+ * to `out`. Attributes are emitted in the canonical order class, id, then the
+ * remaining key=value tokens in source order, each separated from the previous
+ * content by a single space (including from any content already in `out`):
+ *
+ *   .class tokens (and the `{-}`/`.unnumbered` shorthand) -> one class="..."
+ *     attribute, each class prefixed by `class_prefix` on the FIRST class only
+ *     (pass "language-" for code blocks, "" elsewhere);
+ *   #id (first one wins)                                  -> id="...";
+ *   key=value (or bare key)                               -> emitted verbatim.
+ *
+ * This is the single source of truth shared by the code-block render func here
+ * and R's convert_attrs() (via the R_convert_attrs binding in parse.c). */
+void litedown_render_attrs(cmark_strbuf *out, const unsigned char *d,
+                           bufsize_t len, const char *class_prefix) {
+  bufsize_t i, tok, tend;
+  int n_class = 0;
+
+  /* class attribute: all .class tokens (and {-}/.unnumbered), in source order */
+  for (i = 0; next_token(d, len, &i, &tok, &tend);) {
+    int is_class = d[tok] == '.' && tend - tok > 1;
+    int is_dash = d[tok] == '-' && tend - tok == 1;
+    if (!is_class && !is_dash)
+      continue;
+    if (n_class == 0) {
+      if (out->size)
+        cmark_strbuf_putc(out, ' ');
+      cmark_strbuf_puts(out, "class=\"");
+      cmark_strbuf_puts(out, class_prefix);
+    } else {
+      cmark_strbuf_putc(out, ' ');
+    }
+    if (is_dash)
+      cmark_strbuf_puts(out, "unnumbered");
+    else
+      houdini_escape_html0(out, d + tok + 1, tend - tok - 1, 0);
+    n_class++;
+  }
+  if (n_class > 0)
+    cmark_strbuf_putc(out, '"');
+
+  /* id attribute (first #id wins) */
+  for (i = 0; next_token(d, len, &i, &tok, &tend);) {
+    if (d[tok] == '#' && tend - tok > 1) {
+      if (out->size)
+        cmark_strbuf_putc(out, ' ');
+      cmark_strbuf_puts(out, "id=\"");
+      houdini_escape_html0(out, d + tok + 1, tend - tok - 1, 0);
+      cmark_strbuf_putc(out, '"');
+      break;
+    }
+  }
+
+  /* remaining key=value (or bare key) attributes, verbatim, in source order */
+  for (i = 0; next_token(d, len, &i, &tok, &tend);) {
+    if (d[tok] == '.' || d[tok] == '#' ||
+        (d[tok] == '-' && tend - tok == 1))
+      continue;
+    if (out->size)
+      cmark_strbuf_putc(out, ' ');
+    cmark_strbuf_put(out, d + tok, tend - tok);
+  }
 }
 
 /* Render func: build the opening <pre><code ...> tag from the attribute list,
@@ -97,99 +181,25 @@ static void html_render(cmark_syntax_extension *extension,
   cmark_strbuf *html = renderer->html;
   cmark_chunk *info = &node->as.code.info;
   cmark_chunk *lit = &node->as.code.literal;
-  const unsigned char *d = info->data;
-  bufsize_t start, end, i;
-  int n_class = 0, have_id = 0;
-  /* buffer for the remaining (key=value) attributes, emitted after class/id */
-  cmark_strbuf rest = CMARK_BUF_INIT(renderer->html->mem);
+  cmark_strbuf attrs = CMARK_BUF_INIT(html->mem);
+  bufsize_t start, end;
   (void)extension;
 
   if (ev_type != CMARK_EVENT_ENTER)
     return;
 
   attr_body(info, &start, &end);
+  litedown_render_attrs(&attrs, info->data + start, end - start, "language-");
 
   cmark_html_render_cr(html);
   cmark_strbuf_puts(html, "<pre");
   cmark_html_render_sourcepos(node, html, options);
   cmark_strbuf_puts(html, "><code");
-
-  /* First pass: emit the class attribute, collecting all .class tokens (and the
-   * {-} / .unnumbered shorthand). We scan the whole body, skipping non-class
-   * tokens, so classes always come first regardless of source order. */
-  i = start;
-  while (i < end) {
-    bufsize_t tok, tend;
-    /* skip spaces */
-    while (i < end && (d[i] == ' ' || d[i] == '\t'))
-      i++;
-    if (i >= end)
-      break;
-    tok = i;
-    /* a token runs to the next space, but a quoted value may contain spaces */
-    while (i < end && d[i] != ' ' && d[i] != '\t') {
-      if (d[i] == '"') {
-        i++;
-        while (i < end && d[i] != '"')
-          i++;
-      }
-      i++;
-    }
-    tend = i;
-    if (d[tok] == '.' && tend - tok > 1) {
-      if (n_class == 0)
-        cmark_strbuf_puts(html, " class=\"language-");
-      else
-        cmark_strbuf_putc(html, ' ');
-      put_value(html, d + tok + 1, tend - tok - 1);
-      n_class++;
-    } else if (d[tok] == '-' && tend - tok == 1) {
-      /* {-} is shorthand for .unnumbered */
-      if (n_class == 0)
-        cmark_strbuf_puts(html, " class=\"language-");
-      else
-        cmark_strbuf_putc(html, ' ');
-      cmark_strbuf_puts(html, "unnumbered");
-      n_class++;
-    }
+  if (attrs.size) {
+    cmark_strbuf_putc(html, ' ');
+    cmark_strbuf_put(html, attrs.ptr, attrs.size);
   }
-  if (n_class > 0)
-    cmark_strbuf_putc(html, '"');
-
-  /* Second pass: id (#id, first one wins) and remaining key=value attributes,
-   * in source order, buffered in `rest`. */
-  i = start;
-  while (i < end) {
-    bufsize_t tok, tend;
-    while (i < end && (d[i] == ' ' || d[i] == '\t'))
-      i++;
-    if (i >= end)
-      break;
-    tok = i;
-    while (i < end && d[i] != ' ' && d[i] != '\t') {
-      if (d[i] == '"') {
-        i++;
-        while (i < end && d[i] != '"')
-          i++;
-      }
-      i++;
-    }
-    tend = i;
-    if (d[tok] == '#' && tend - tok > 1) {
-      if (!have_id) {
-        cmark_strbuf_puts(html, " id=\"");
-        put_value(html, d + tok + 1, tend - tok - 1);
-        cmark_strbuf_putc(html, '"');
-        have_id = 1;
-      }
-    } else if (d[tok] != '.' && !(d[tok] == '-' && tend - tok == 1)) {
-      /* a key=value (or bare key) attribute: emit verbatim, space-separated */
-      cmark_strbuf_putc(&rest, ' ');
-      cmark_strbuf_put(&rest, d + tok, tend - tok);
-    }
-  }
-  cmark_strbuf_put(html, rest.ptr, rest.size);
-  cmark_strbuf_free(&rest);
+  cmark_strbuf_free(&attrs);
 
   cmark_strbuf_putc(html, '>');
   houdini_escape_html0(html, lit->data, lit->len, 0);

--- a/src/extensions/attributes.h
+++ b/src/extensions/attributes.h
@@ -2,7 +2,15 @@
 #define LITEDOWN_ATTRIBUTES_H
 
 #include "cmark-gfm-core-extensions.h"
+#include "buffer.h"
 
 cmark_syntax_extension *create_attributes_extension(void);
+
+/* Append an HTML attribute string (class, id, then key=value tokens) built from
+ * a Pandoc-style attribute list body to `out`. Shared by the code-block render
+ * func and R's convert_attrs() via the R_convert_attrs binding. See the
+ * definition in attributes.c for the exact ordering/escaping rules. */
+void litedown_render_attrs(cmark_strbuf *out, const unsigned char *d,
+                           bufsize_t len, const char *class_prefix);
 
 #endif

--- a/src/init.c
+++ b/src/init.c
@@ -9,6 +9,7 @@ extern SEXP R_render_markdown(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SE
 extern SEXP R_parse_markdown(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP R_code_tokens(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP R_prose_lines(SEXP);
+extern SEXP R_convert_attrs(SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
   {"R_list_extensions", (DL_FUNC) &R_list_extensions, 0},
@@ -16,6 +17,7 @@ static const R_CallMethodDef CallEntries[] = {
   {"R_parse_markdown",  (DL_FUNC) &R_parse_markdown,  7},
   {"R_code_tokens",     (DL_FUNC) &R_code_tokens,     6},
   {"R_prose_lines",     (DL_FUNC) &R_prose_lines,     1},
+  {"R_convert_attrs",   (DL_FUNC) &R_convert_attrs,   2},
   {NULL, NULL, 0}
 };
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -9,7 +9,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include "parser.h"
+#include "buffer.h"
 #include "extensions/litedown-extensions.h"
+#include "extensions/attributes.h"
 
 /* Build a nested R list for a node and all of its descendants. Each node is a
  * named list with fields:
@@ -331,5 +333,47 @@ SEXP R_prose_lines(SEXP text) {
   }
 
   UNPROTECT(2);
+  return out;
+}
+
+/* Convert Pandoc-style attribute list bodies to HTML attribute strings, sharing
+ * the C implementation used to render code block attributes (see
+ * litedown_render_attrs in extensions/attributes.c). This is the engine behind
+ * R's convert_attrs(): `specs` is a character vector where each element is the
+ * text inside the braces (e.g. `.r .js #foo k="v"`), already stripped of the
+ * curly braces and preprocessed by R (curly-quote / LaTeX-escape normalization).
+ * Returns a character vector of the same length, each the assembled attribute
+ * string in the canonical order class, id, then key=value tokens. `prefix` is
+ * the string prepended to the first class (e.g. "" for headings/links/divs;
+ * the code-block render func passes "language-" directly). NA inputs map to NA. */
+SEXP R_convert_attrs(SEXP specs, SEXP prefix) {
+  if (!Rf_isString(specs))
+    Rf_error("Argument 'specs' must be a character vector.");
+  if (!Rf_isString(prefix) || Rf_length(prefix) != 1)
+    Rf_error("Argument 'prefix' must be a single string.");
+
+  const char *pfx = Rf_translateCharUTF8(STRING_ELT(prefix, 0));
+  int n = Rf_length(specs);
+  SEXP out = PROTECT(Rf_allocVector(STRSXP, n));
+  cmark_mem *mem = cmark_get_default_mem_allocator();
+
+  for (int i = 0; i < n; i++) {
+    SEXP s = STRING_ELT(specs, i);
+    if (s == NA_STRING) {
+      SET_STRING_ELT(out, i, NA_STRING);
+      continue;
+    }
+    {
+      const char *d = Rf_translateCharUTF8(s);
+      cmark_strbuf buf = CMARK_BUF_INIT(mem);
+      litedown_render_attrs(&buf, (const unsigned char *) d,
+                            (bufsize_t) strlen(d), pfx);
+      cmark_strbuf_putc(&buf, '\0');
+      SET_STRING_ELT(out, i, Rf_mkCharCE((const char *) buf.ptr, CE_UTF8));
+      cmark_strbuf_free(&buf);
+    }
+  }
+
+  UNPROTECT(1);
   return out;
 }

--- a/src/patches/README.md
+++ b/src/patches/README.md
@@ -41,8 +41,12 @@ overwrite them with upstream `src/` files:
   extension (```` ```{.class #id key="val"} ````): a postprocess pass tags the
   matching code blocks and its HTML render func emits the attributes on
   `<pre><code>` (`.class` → `class`, `#id` → `id`, `{-}` → `.unnumbered`,
-  `key=value` verbatim). Only the HTML render func is set, so other output
-  formats keep cmark's built-in code-block rendering. Written for litedown.
+  `key=value` verbatim, in the order class, id, rest). Only the HTML render func
+  is set, so other output formats keep cmark's built-in code-block rendering.
+  The attribute-string builder (`litedown_render_attrs()`) is also exposed to R
+  via the `R_convert_attrs` binding in `parse.c`, so R's `convert_attrs()`
+  (which handles the same syntax on headings/links/divs/images) shares this one
+  implementation. Written for litedown.
 - `src/extensions/rawblock.c` / `.h` — raw content block extension
   (```` ```{=html} ````, ```` ```{=latex} ````, ```` ```{=tex} ````): a
   postprocess pass tags the matching code blocks with the extension so its

--- a/tests/test-cran/test-mark.R
+++ b/tests/test-cran/test-mark.R
@@ -145,6 +145,25 @@ assert('mark() renders raw content blocks via the C extension', {
      '<p>before</p>\n<hr>\n<p>after</p>')
 })
 
+assert('mark() applies {.class #id key=val} attributes in a canonical order', {
+  # convert_attrs() (headings/links/divs) and the code block 'attributes'
+  # extension share one C implementation, so all of them emit attributes in the
+  # order class, id, then the remaining key=value tokens (in source order),
+  # regardless of the order the tokens appear in the source
+  (mark2('# Hi {.foo .bar #baz style="x"}') %==%
+     '<h1 class="foo bar" id="baz" style="x">Hi</h1>')
+  # tokens in a scrambled order still come out class, id, rest
+  (mark2('# Hi {style="a" .foo k="b" #id}') %==%
+     '<h1 class="foo" id="id" style="a" k="b">Hi</h1>')
+  # a fenced Div and an inline link use the same ordering
+  (mark2(c('::: {#baz .foo}', 'x', ':::')) %==%
+     '<div class="foo" id="baz">\n<p>x</p>\n</div>')
+  (mark2('[t](u){#baz .foo}') %==% '<p><a href="u" class="foo" id="baz">t</a></p>')
+  # a code block goes through the same C core (with the language- class prefix)
+  (mark2(c('```{#baz .foo}', 'x', '```')) %==%
+     '<pre><code class="language-foo" id="baz">x\n</code></pre>')
+})
+
 assert('mark() renders a raw LaTeX math environment as math in HTML too', {
   # documented exception: a raw {=latex}/{=tex} block that is a math environment
   # is wrapped in <p>...</p> for HTML so the JS math library can typeset it


### PR DESCRIPTION
Follow-up to #157. The code block `attributes` extension and R's `convert_attrs()` parsed the same Pandoc-style `{.class #id key="val"}` syntax with two separate implementations. This extracts the attribute-string builder in `attributes.c` into `litedown_render_attrs()` and exposes it to R through a new `R_convert_attrs` binding in `parse.c`, so both share one implementation.

- **`attributes.c`**: `html_render()` calls `litedown_render_attrs()` (with the `language-` class prefix) instead of its own two inline passes.
- **`parse.c`**: `R_convert_attrs(specs, prefix)` runs the same builder over a character vector of brace-body strings and returns the assembled attribute strings.
- **`R/utils.R`**: `convert_attrs()` keeps its per-element capture extraction, format-specific preprocessing (curly quotes, LaTeX escaping) and the `f()`/`f2()` callbacks, but delegates the `.class`/`#id`/`{-}`/`key=value` assembly to `R_convert_attrs()` instead of the in-R `match_replace()` reordering.

### Behavior change (order only, not meaning)

Both paths now emit attributes in one canonical order: **class, id, then the remaining `key=value` tokens in source order**. Previously `convert_attrs()` emitted id before class and left `key=value` tokens in their original position. This changes the attribute *order* of headings/links/divs/images in HTML output; the only affected rendered example (a fenced Div in `examples/test-options.md`) is updated:

```diff
-<div id="baz" class="foo bar" style="color: red;">
+<div class="foo bar" id="baz" style="color: red;">
```

Verified: full `test-cran` suite passes (new ordering assertions in `test-mark.R`), no compiler warnings, rendered examples differ only by the documented reordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)