### PR TITLE
Expand test coverage across R and C code

### DIFF
--- a/tests/test-cran/test-format.R
+++ b/tests/test-cran/test-format.R
@@ -1,0 +1,96 @@
+library(testit)
+
+assert('normalize_yaml() renames rmarkdown output formats to litedown formats', {
+  # a bare string output format with no options
+  (normalize_yaml(list(output = 'html_document'))$output %==% list(html = list()))
+  # pdf_document -> latex, html_vignette -> html
+  (names(normalize_yaml(list(output = 'pdf_document'))$output) %==% 'latex')
+  (names(normalize_yaml(list(output = 'html_vignette'))$output) %==% 'html')
+  # the `format` key is normalized to `output`
+  y = normalize_yaml(list(format = 'html'))
+  (is.null(y$format))
+  (names(y$output) %==% 'html')
+  # litedown::/markdown:: prefixes and _format suffixes are stripped
+  (names(normalize_yaml(list(output = 'litedown::html_format'))$output) %==% 'html')
+  (names(normalize_yaml(list(output = 'markdown::latex_format'))$output) %==% 'latex')
+  # no output/format field -> NULL (nothing to normalize)
+  (is.null(normalize_yaml(list(title = 'x'))))
+})
+
+assert('normalize_yaml() maps rmarkdown output options through map_args()', {
+  y = normalize_yaml(list(output = list(pdf_document = list(toc = TRUE))))
+  o = y$output$latex
+  (o$options$toc$depth %==% 3)
+  (o$meta$css %==% 'default')
+})
+
+assert('normalize_yaml() errors on a non-list, non-character output field', {
+  (has_error(normalize_yaml(list(output = 1:3))))
+})
+
+assert('detect_format() detects the format from the output name or extension', {
+  # a known format name is returned as-is
+  (detect_format('html', NULL) %==% 'html')
+  (detect_format('latex', NULL) %==% 'latex')
+  # .pdf implies latex
+  (detect_format('.pdf', NULL) %==% 'latex')
+  (detect_format('out.pdf', NULL) %==% 'latex')
+  # a file extension maps to its format
+  (detect_format('foo.html', NULL) %==% 'html')
+  (detect_format('foo.tex', NULL) %==% 'latex')
+  (detect_format('foo.md', NULL) %==% 'markdown')
+  # markdown:xxx reports the final format (markdown is the intermediate step)
+  (detect_format('markdown:latex', NULL) %==% 'latex')
+})
+
+assert('detect_format() falls back to the YAML output format', {
+  # a non-character output falls through to yaml_format()
+  (detect_format(NULL, list(output = list(latex = list()))) %==% 'latex')
+  # unknown extension with no YAML defaults to html
+  (detect_format(NULL, list()) %==% 'html')
+})
+
+assert('yaml_format() returns the first output format or defaults to html', {
+  (yaml_format(list(output = list(latex = list(), html = list()))) %==% 'latex')
+  (yaml_format(list(output = 'text')) %==% 'text')
+  # no output field -> html
+  (yaml_format(list()) %==% 'html')
+})
+
+assert('yaml_field() extracts a named field under an output format', {
+  y = list(output = list(html = list(meta = list(css = 'x'), options = list(toc = TRUE))))
+  (yaml_field(y, 'html', 'meta') %==% list(css = 'x'))
+  (yaml_field(y, 'html', 'options') %==% list(toc = TRUE))
+  # a length>1 name selects a sublist
+  (names(yaml_field(y, 'html', c('meta', 'options'))) %==% c('meta', 'options'))
+  # missing format -> NULL
+  (is.null(yaml_field(y, 'latex', 'meta')))
+})
+
+assert('map_args() maps rmarkdown html_document arguments to litedown options', {
+  a = map_args(toc = TRUE, toc_depth = 2, number_sections = TRUE)
+  (a$options$toc$depth %==% 2)
+  (isTRUE(a$options$number_sections))
+  (a$meta$css %==% 'default')
+  # self_contained maps to embed_resources
+  (isFALSE(map_args(self_contained = FALSE)$options$embed_resources))
+})
+
+assert('map_args() adds assets for mathjax, anchors, and code folding', {
+  a = map_args(math_method = 'mathjax', anchor_sections = TRUE, code_folding = 'show')
+  (a$options$js_math %==% 'mathjax')
+  ('@heading-anchor' %in% a$meta$js)
+  ('@heading-anchor' %in% a$meta$css)
+  ('@fold-details' %in% a$meta$js)
+  # math_method as a list uses its $engine
+  (map_args(math_method = list(engine = 'mathjax'))$options$js_math %==% 'mathjax')
+  # extra css is appended after 'default'
+  (map_args(css = 'custom.css')$meta$css %==% c('default', 'custom.css'))
+})
+
+assert('map_args() maps rmarkdown includes to litedown meta fields', {
+  a = map_args(includes = list(in_header = 'h', before_body = 'b', after_body = 'a'))
+  (a$meta$header_includes %==% 'h')
+  (a$meta$include_before %==% 'b')
+  (a$meta$include_after %==% 'a')
+})

--- a/tests/test-cran/test-fuse.R
+++ b/tests/test-cran/test-fuse.R
@@ -77,81 +77,16 @@ assert('fiss() respects purl = FALSE chunk option', {
   (c('public = 2', '') %==% as.character(out))
 })
 
-# fuse() code chunk output ---------------------------------------------------
+# fuse() code chunk / inline output is snapshot-tested in test-fuse.md; the
+# asserts below cover behavior that isn't a simple output comparison (S3
+# classes, and the register/restore lifecycle of a custom engine).
 
-md = function(...) as.character(fuse(..., output = 'markdown'))
-
-assert('fuse() echoes source and prints the value of a code chunk', {
-  out = md(text = c('```{r}', '1 + 1', '```'))
-  (grepl('1 + 1', out, fixed = TRUE))          # source echoed
-  (grepl('#> [1] 2', out, fixed = TRUE))  # printed value with default comment
-})
-
-assert('fuse() honors echo=FALSE and eval=FALSE', {
-  # echo=FALSE hides the source but keeps the output
-  out = md(text = c('```{r echo=FALSE}', '1 + 1', '```'))
-  (!grepl('1 + 1', out, fixed = TRUE))
-  (grepl('#> [1] 2', out, fixed = TRUE))
-  # eval=FALSE keeps the source but produces no output
-  out = md(text = c('```{r eval=FALSE}', '1 + 1', '```'))
-  (grepl('1 + 1', out, fixed = TRUE))
-  (!grepl('#>', out, fixed = TRUE))
-})
-
-assert('fuse() captures errors, warnings, and messages with error=TRUE', {
-  # error=TRUE turns a stop() into an error block instead of aborting
-  out = md(text = c('```{r error=TRUE}', 'stop("boom")', '```'))
-  (grepl('.error', out, fixed = TRUE))
-  (grepl('boom', out))
-  # warnings and messages get their own labeled blocks
-  (grepl('.warning', md(text = c('```{r}', 'warning("careful")', '```')), fixed = TRUE))
-  (grepl('.message', md(text = c('```{r}', 'message("hi")', '```')), fixed = TRUE))
-})
-
-assert('fuse() supports results="hide" and results="asis"', {
-  # hide: source kept, printed value suppressed
-  out = md(text = c('```{r results="hide"}', '1 + 1', '```'))
-  (!grepl('#>', out, fixed = TRUE))
-  # asis: cat() output is emitted as raw Markdown (a real heading)
-  out = md(text = c('```{r results="asis"}', 'cat("# Heading")', '```'))
-  (grepl('# Heading', out, fixed = TRUE))
-})
-
-assert('fuse() collapses source and output when collapse=TRUE', {
-  out = md(text = c('```{r collapse=TRUE}', '1 + 1', '2 + 2', '```'))
-  # a single fenced block holds both the code and the interleaved output
-  (grepl('1 + 1\n#> [1] 2', out, fixed = TRUE))
-  (grepl('2 + 2\n#> [1] 4', out, fixed = TRUE))
-})
-
-assert('fuse() uses a custom output comment prefix', {
-  out = md(text = c('```{r comment="##"}', '1 + 1', '```'))
-  (grepl('##[1] 2', out, fixed = TRUE))
-})
-
-assert('fuse() evaluates inline code and formats numbers as LaTeX math', {
-  # a large number switches to scientific notation rendered as math
-  (grepl('$10^{6}$', md(text = 'Val: `{r} 1e6`.'), fixed = TRUE))
-  # a small integer is printed verbatim
-  (grepl('Val: 42.', md(text = 'Val: `{r} 42`.'), fixed = TRUE))
-  # a character result is inserted as-is
-  (grepl('Name: ab.', md(text = 'Name: `{r} paste0("a", "b")`.'), fixed = TRUE))
-})
-
-assert('fuse() exposes fuse_env() and get_context() during evaluation', {
-  # fuse_env() returns the chunk evaluation environment
-  out = md(text = c('```{r}', 'is.environment(fuse_env())', '```'))
-  (grepl('#> [1] TRUE', out, fixed = TRUE))
-  # get_context('format') returns the current output format inside fuse()
-  out = md(text = c('```{r results="asis"}', 'cat(get_context("format"))', '```'))
-  (grepl('markdown', out))
-})
-
-assert('engines() allows registering a custom block/inline engine used by fuse()', {
-  old = engines(foo = function(x, inline = FALSE, ...) if (inline) 'INLINE' else 'BLOCK')
-  on.exit(engines(old), add = TRUE)
-  (grepl('BLOCK', md(text = c('```{foo}', 'anything', '```'))))
-  (grepl('x INLINE z', md(text = 'x `{foo} y` z')))
+assert('engines() registers a custom engine and restores the old value', {
+  (is.null(engines('foo')))
+  old = engines(foo = function(x, inline = FALSE, ...) 'x')
+  (is.function(engines('foo')))
+  engines(old)  # restore
+  (is.null(engines('foo')))
 })
 
 assert('raw_text() wraps content in a raw block for a given format', {
@@ -161,9 +96,4 @@ assert('raw_text() wraps content in a raw block for a given format', {
   (grepl('<b>hi</b>', x, fixed = TRUE))
   # no format leaves the content unfenced
   (as.character(raw_text('plain')) %==% 'plain')
-})
-
-assert('fuse() renders raw_text() output verbatim (not as a code block)', {
-  out = md(text = c('```{r results="asis"}', 'litedown::raw_text("<hr/>", "html")', '```'))
-  (grepl('<hr/>', out, fixed = TRUE))
 })

--- a/tests/test-cran/test-fuse.R
+++ b/tests/test-cran/test-fuse.R
@@ -76,3 +76,94 @@ assert('fiss() respects purl = FALSE chunk option', {
   out = fiss(I(src))
   (c('public = 2', '') %==% as.character(out))
 })
+
+# fuse() code chunk output ---------------------------------------------------
+
+md = function(...) as.character(fuse(..., output = 'markdown'))
+
+assert('fuse() echoes source and prints the value of a code chunk', {
+  out = md(text = c('```{r}', '1 + 1', '```'))
+  (grepl('1 + 1', out, fixed = TRUE))          # source echoed
+  (grepl('#> [1] 2', out, fixed = TRUE))  # printed value with default comment
+})
+
+assert('fuse() honors echo=FALSE and eval=FALSE', {
+  # echo=FALSE hides the source but keeps the output
+  out = md(text = c('```{r echo=FALSE}', '1 + 1', '```'))
+  (!grepl('1 + 1', out, fixed = TRUE))
+  (grepl('#> [1] 2', out, fixed = TRUE))
+  # eval=FALSE keeps the source but produces no output
+  out = md(text = c('```{r eval=FALSE}', '1 + 1', '```'))
+  (grepl('1 + 1', out, fixed = TRUE))
+  (!grepl('#>', out, fixed = TRUE))
+})
+
+assert('fuse() captures errors, warnings, and messages with error=TRUE', {
+  # error=TRUE turns a stop() into an error block instead of aborting
+  out = md(text = c('```{r error=TRUE}', 'stop("boom")', '```'))
+  (grepl('.error', out, fixed = TRUE))
+  (grepl('boom', out))
+  # warnings and messages get their own labeled blocks
+  (grepl('.warning', md(text = c('```{r}', 'warning("careful")', '```')), fixed = TRUE))
+  (grepl('.message', md(text = c('```{r}', 'message("hi")', '```')), fixed = TRUE))
+})
+
+assert('fuse() supports results="hide" and results="asis"', {
+  # hide: source kept, printed value suppressed
+  out = md(text = c('```{r results="hide"}', '1 + 1', '```'))
+  (!grepl('#>', out, fixed = TRUE))
+  # asis: cat() output is emitted as raw Markdown (a real heading)
+  out = md(text = c('```{r results="asis"}', 'cat("# Heading")', '```'))
+  (grepl('# Heading', out, fixed = TRUE))
+})
+
+assert('fuse() collapses source and output when collapse=TRUE', {
+  out = md(text = c('```{r collapse=TRUE}', '1 + 1', '2 + 2', '```'))
+  # a single fenced block holds both the code and the interleaved output
+  (grepl('1 + 1\n#> [1] 2', out, fixed = TRUE))
+  (grepl('2 + 2\n#> [1] 4', out, fixed = TRUE))
+})
+
+assert('fuse() uses a custom output comment prefix', {
+  out = md(text = c('```{r comment="##"}', '1 + 1', '```'))
+  (grepl('##[1] 2', out, fixed = TRUE))
+})
+
+assert('fuse() evaluates inline code and formats numbers as LaTeX math', {
+  # a large number switches to scientific notation rendered as math
+  (grepl('$10^{6}$', md(text = 'Val: `{r} 1e6`.'), fixed = TRUE))
+  # a small integer is printed verbatim
+  (grepl('Val: 42.', md(text = 'Val: `{r} 42`.'), fixed = TRUE))
+  # a character result is inserted as-is
+  (grepl('Name: ab.', md(text = 'Name: `{r} paste0("a", "b")`.'), fixed = TRUE))
+})
+
+assert('fuse() exposes fuse_env() and get_context() during evaluation', {
+  # fuse_env() returns the chunk evaluation environment
+  out = md(text = c('```{r}', 'is.environment(fuse_env())', '```'))
+  (grepl('#> [1] TRUE', out, fixed = TRUE))
+  # get_context('format') returns the current output format inside fuse()
+  out = md(text = c('```{r results="asis"}', 'cat(get_context("format"))', '```'))
+  (grepl('markdown', out))
+})
+
+assert('engines() allows registering a custom block/inline engine used by fuse()', {
+  old = engines(foo = function(x, inline = FALSE, ...) if (inline) 'INLINE' else 'BLOCK')
+  on.exit(engines(old), add = TRUE)
+  (grepl('BLOCK', md(text = c('```{foo}', 'anything', '```'))))
+  (grepl('x INLINE z', md(text = 'x `{foo} y` z')))
+})
+
+assert('raw_text() wraps content in a raw block for a given format', {
+  x = one_string(as.character(raw_text('<b>hi</b>', 'html')))
+  (inherits(raw_text('<b>hi</b>', 'html'), 'record_asis'))
+  (grepl('{=html}', x, fixed = TRUE))
+  (grepl('<b>hi</b>', x, fixed = TRUE))
+  # no format leaves the content unfenced
+  (as.character(raw_text('plain')) %==% 'plain')
+})
+
+assert('fuse() renders raw_text() output verbatim (not as a code block)', {
+  out = md(text = c('```{r results="asis"}', 'litedown::raw_text("<hr/>", "html")', '```'))
+  (grepl('<hr/>', out, fixed = TRUE))
+})

--- a/tests/test-cran/test-fuse.md
+++ b/tests/test-cran/test-fuse.md
@@ -2,11 +2,11 @@
 
 ## Basic code chunk execution
 
-````r
+`````r
 library(litedown)
 fuse(text = c('```{r}', '1 + 1', '```'), output = 'markdown')
-````
-````
+`````
+`````
 ``` {.r}
 1 + 1
 ```
@@ -14,65 +14,65 @@ fuse(text = c('```{r}', '1 + 1', '```'), output = 'markdown')
 ```
 #> [1] 2
 ```
-````
+`````
 
 ## Inline code evaluation
 
-````r
+`````r
 fuse(text = 'Value is `{r} 1 + 1`.', output = 'markdown')
-````
-````
+`````
+`````
 Value is 2.
-````
+`````
 
 ## echo = FALSE hides source, shows output
 
-````r
+`````r
 fuse(text = c('```{r, echo=FALSE}', '2 * 3', '```'), output = 'markdown')
-````
-````
+`````
+`````
 ```
 #> [1] 6
 ```
-````
+`````
 
 ## eval = FALSE doesn't run code
 
-````r
+`````r
 fuse(text = c('```{r, eval=FALSE}', 'stop("No")', '```'), output = 'markdown')
-````
-````
+`````
+`````
 ``` {.r}
 stop("No")
 ```
-````
+`````
 
 ## results = FALSE suppresses output
 
-````r
+`````r
 fuse(text = c('```{r, results=FALSE}', '1 + 1', '```'), output = 'markdown')
-````
-````
+`````
+`````
 ``` {.r}
 1 + 1
 ```
-````
+`````
 
 ## include = FALSE produces no output at all
 
-````r
+`````r
 fuse(text = c('```{r, include=FALSE}', '1 + 1', '```'), output = 'markdown')
-````
-````
+`````
+`````
 
-````
+`````
 
 ## comment option prefixes each output line
 
-````r
+`````r
 fuse(text = c('```{r, comment="##"}', '1:3', '```'), output = 'markdown')
-````
-````
+`````
+`````
 ``` {.r}
 1:3
 ```
@@ -80,14 +80,14 @@ fuse(text = c('```{r, comment="##"}', '1:3', '```'), output = 'markdown')
 ```
 ##[1] 1 2 3
 ```
-````
+`````
 
 ## comment = "" produces no prefix
 
-````r
+`````r
 fuse(text = c('```{r, comment=""}', '1:3', '```'), output = 'markdown')
-````
-````
+`````
+`````
 ``` {.r}
 1:3
 ```
@@ -95,28 +95,28 @@ fuse(text = c('```{r, comment=""}', '1:3', '```'), output = 'markdown')
 ```
 [1] 1 2 3
 ```
-````
+`````
 
 ## collapse = TRUE merges source and output blocks
 
-````r
+`````r
 fuse(text = c('```{r, collapse=TRUE}', '1 + 1', '2 + 2', '```'), output = 'markdown')
-````
-````
+`````
+`````
 ``` {.r}
 1 + 1
 #> [1] 2
 2 + 2
 #> [1] 4
 ```
-````
+`````
 
 ## results = "asis" output is written verbatim (no code fence)
 
-````r
+`````r
 fuse(text = c('#| results="asis"', 'cat("<p>hi</p>\\n")', '#| foo', '1:2'), output = 'markdown')
-````
-````
+`````
+`````
 ``` {.r}
 cat("<p>hi</p>\n")
 ```
@@ -128,14 +128,14 @@ cat("<p>hi</p>\n")
 ```
 #> [1] 1 2
 ```
-````
+`````
 
 ## error = TRUE captures errors instead of stopping
 
-````r
+`````r
 fuse(text = c('```{r, error=TRUE}', 'stop("oops")', '```'), output = 'markdown')
-````
-````
+`````
+`````
 ``` {.r}
 stop("oops")
 ```
@@ -143,14 +143,14 @@ stop("oops")
 ``` {.plain .error}
 #> Error: oops
 ```
-````
+`````
 
 ## warning = TRUE includes warnings in output
 
-````r
+`````r
 fuse(text = c('```{r, warning=TRUE}', 'warning("careful!")', '```'), output = 'markdown')
-````
-````
+`````
+`````
 ``` {.r}
 warning("careful!")
 ```
@@ -158,25 +158,25 @@ warning("careful!")
 ``` {.plain .warning}
 #> careful!
 ```
-````
+`````
 
 ## warning = FALSE suppresses warnings
 
-````r
+`````r
 fuse(text = c('```{r, warning=FALSE}', 'warning("shh")', '```'), output = 'markdown')
-````
-````
+`````
+`````
 ``` {.r}
 warning("shh")
 ```
-````
+`````
 
 ## message = TRUE includes messages in output
 
-````r
+`````r
 fuse(text = c('```{r, message=TRUE}', 'message("hey")', '```'), output = 'markdown')
-````
-````
+`````
+`````
 ``` {.r}
 message("hey")
 ```
@@ -184,14 +184,14 @@ message("hey")
 ``` {.plain .message}
 #> hey
 ```
-````
+`````
 
 ## Multiple chunks with independent results
 
-````r
+`````r
 fuse(text = c('```{r}', 'x = 42', '```', '', '```{r}', 'x', '```'), output = 'markdown')
-````
-````
+`````
+`````
 ``` {.r}
 x = 42
 ```
@@ -203,15 +203,76 @@ x
 ```
 #> [1] 42
 ```
-````
+`````
 
 ## Text-only input passes through unchanged
 
-````r
+`````r
 fuse(text = '# Title\n\nJust some text.', output = 'markdown')
-````
-````
+`````
+`````
 # Title
 
 Just some text.
+`````
+
+## Inline code: large numbers render as LaTeX math, others verbatim
+
+`````r
+fuse(text = 'Big `{r} 1e6`, small `{r} 42`, text `{r} paste0("a", "b")`.', output = 'markdown')
+`````
+`````
+Big $10^{6}$, small 42, text ab.
+`````
+
+## A custom engine is used for both block and inline code
+
+`````r
+engines(foo = function(x, inline = FALSE, ...) if (inline) 'INLINE' else 'BLOCK')
+fuse(text = c('```{foo}', 'ignored', '```', '', 'and `{foo} y` inline'), output = 'markdown')
+`````
+`````
+```
+#> BLOCK
+```
+
+and INLINE inline
+`````
+
+## fuse_env() and get_context() are available during evaluation
+
+`````r
+fuse(text = c('```{r}', 'is.environment(fuse_env())', 'get_context("format")', '```'), output = 'markdown')
+`````
+`````
+``` {.r}
+is.environment(fuse_env())
+```
+
+```
+#> [1] TRUE
+```
+
+``` {.r}
+get_context("format")
+```
+
+```
+#> [1] "markdown"
+```
+`````
+
+## results = "asis" with raw_text() emits verbatim HTML
+
+`````r
+fuse(text = c('```{r, results="asis"}', 'raw_text("<hr/>", "html")', '```'), output = 'markdown')
+`````
+`````
+```` {.r}
+raw_text("<hr/>", "html")
 ````
+
+``` {=html}
+<hr/>
+```
+`````

--- a/tests/test-cran/test-package.R
+++ b/tests/test-cran/test-package.R
@@ -1,0 +1,103 @@
+library(testit)
+
+# use the installed litedown package itself as a stable test fixture
+pkg = 'litedown'
+
+# test_pkg() installs a minimal build with no help database, so Rd-based
+# functions (Rd_aliases(), pkg_manual()) can't run there; gate those tests.
+has_rd = !inherits(try(tools::Rd_db(pkg), silent = TRUE), 'try-error')
+
+assert('header_class() builds the {.unlisted .unnumbered} attribute string', {
+  # both off -> both classes (Markdown form)
+  (header_class(FALSE, FALSE) %==% ' {.unlisted .unnumbered}')
+  # toc on but numbering off -> only .unnumbered
+  (header_class(TRUE, FALSE) %==% ' {.unnumbered}')
+  # both on -> empty
+  (header_class(TRUE, TRUE) %==% '')
+  # HTML form uses class="..."
+  (header_class(FALSE, FALSE, FALSE) %==% ' class="unlisted unnumbered"')
+  (header_class(FALSE, TRUE, FALSE) %==% ' class="unlisted"')
+})
+
+assert('github_link() extracts the repo URL from DESCRIPTION BugReports', {
+  u = github_link(system.file(package = pkg))
+  (grepl('^https://github.com/[^/]+/[^/]+/$', u))
+  # a directory with no DESCRIPTION errors (read.dcf fails)
+  (has_error(suppressWarnings(github_link(tempdir()))))
+})
+
+assert('pkg_authors() falls back to the Author field with no Authors@R', {
+  (pkg_authors(list(Author = 'Jane Doe')) %==% 'Jane Doe')
+})
+
+assert('pkg_authors() formats Authors@R with roles, URLs, and ORCID links', {
+  orcid = '0000-0003-0645-5666'
+  desc = list('Authors@R' = sprintf(paste0(
+    'person("Jane", "Doe", role = c("aut", "cre"), ',
+    'comment = c(ORCID = "%s", URL = "https://example.org"))'
+  ), orcid))
+  a = pkg_authors(desc)
+  (grepl('Jane Doe', a))
+  (grepl('https://example.org', a))       # name linked to URL
+  (grepl(paste0('orcid.org/', orcid), a))  # ORCID badge
+  (grepl('\\[aut, cre\\]', a))             # roles shown
+  # role filtering: request only 'cre' keeps the person; 'ctb' drops them
+  (length(pkg_authors(desc, role = 'cre')) == 1L)
+  (length(pkg_authors(desc, role = 'ctb')) == 0L)
+  # extra = FALSE drops roles/ORCID
+  (!grepl('orcid', pkg_authors(desc, extra = FALSE)))
+})
+
+assert('tweak_citation() fills in a missing year', {
+  x = tweak_citation(suppressWarnings(citation(pkg)))
+  (!is.null(unclass(x)[[1]]$year))
+})
+
+assert('detect_news() finds NEWS.md via the package path or installed package', {
+  # installed package: falls back to system.file()
+  p = detect_news(pkg)
+  (is.character(p))
+  (basename(p) %==% 'NEWS.md')
+})
+
+if (has_rd) assert('Rd_aliases() extracts \\alias entries from an Rd object', {
+  db = tools::Rd_db(pkg)
+  nm = names(db)[1]
+  al = Rd_aliases(db[[nm]])
+  (is.character(al))
+  (length(al) >= 1L)
+})
+
+assert('pkg_desc() renders package metadata as an HTML table or definition list', {
+  tab = pkg_desc(pkg, 'table')
+  (any(grepl('<table', tab)))
+  (any(grepl('Version', tab)))
+  # single quotes in Title/Description are stripped (sans_sq)
+  dl = pkg_desc(pkg, 'dl')
+  (any(grepl('<dl', dl)))
+  (any(grepl('<dt>Version</dt>', dl, fixed = TRUE)))
+})
+
+assert('pkg_citation() returns text and BibTeX citations', {
+  ci = suppressWarnings(pkg_citation(pkg))
+  (length(ci) > 0L)
+  # a fenced ``` latex block holds the BibTeX entry
+  (any(grepl('``` latex', ci, fixed = TRUE)))
+  (any(grepl('@Manual|@Misc|@Article', ci)))
+})
+
+assert('pkg_news() returns news entries with lowered heading levels', {
+  n = suppressWarnings(pkg_news(pkg, recent = 1))
+  (length(n) > 0L)
+  # NEWS.md top-level '# ' headings are lowered to '## '
+  (any(grepl('^## ', n)))
+})
+
+if (has_rd) assert('pkg_manual() renders all man pages with section ids and a TOC', {
+  m = pkg_manual(pkg, toc = TRUE, number_sections = FALSE, examples = FALSE)
+  (length(m) > 0L)
+  # each man page heading carries an id of the form sec:man-<topic>
+  (any(grepl('id="sec:man-', m)))
+  # the alias TOC links back to those sections
+  (any(grepl('href="#sec:man-', m)))
+})

--- a/tests/test-cran/test-package.R
+++ b/tests/test-cran/test-package.R
@@ -7,6 +7,10 @@ pkg = 'litedown'
 # functions (Rd_aliases(), pkg_manual()) can't run there; gate those tests.
 has_rd = !inherits(try(tools::Rd_db(pkg), silent = TRUE), 'try-error')
 
+# NEWS.md is not always installed (e.g., older R versions don't ship it in the
+# package's installed dir), so gate NEWS-based tests on its presence.
+has_news = file_exists(detect_news(pkg))
+
 assert('header_class() builds the {.unlisted .unnumbered} attribute string', {
   # both off -> both classes (Markdown form)
   (header_class(FALSE, FALSE) %==% ' {.unlisted .unnumbered}')
@@ -53,7 +57,7 @@ assert('tweak_citation() fills in a missing year', {
   (!is.null(unclass(x)[[1]]$year))
 })
 
-assert('detect_news() finds NEWS.md via the package path or installed package', {
+if (has_news) assert('detect_news() finds NEWS.md via the package path or installed package', {
   # installed package: falls back to system.file()
   p = detect_news(pkg)
   (is.character(p))
@@ -86,7 +90,7 @@ assert('pkg_citation() returns text and BibTeX citations', {
   (any(grepl('@Manual|@Misc|@Article', ci)))
 })
 
-assert('pkg_news() returns news entries with lowered heading levels', {
+if (has_news) assert('pkg_news() returns news entries with lowered heading levels', {
   n = suppressWarnings(pkg_news(pkg, recent = 1))
   (length(n) > 0L)
   # NEWS.md top-level '# ' headings are lowered to '## '

--- a/tests/test-cran/test-preview.R
+++ b/tests/test-cran/test-preview.R
@@ -10,12 +10,13 @@ assert('is_lite_ext() recognizes extensions litedown can render', {
 })
 
 assert('is_text_file() detects text files by extension or MIME type', {
+  # the extension branch (js/tex/xml/...) doesn't need the file to exist
   (is_text_file(file = 'a.js'))
   (is_text_file(file = 'a.tex'))
   (is_text_file(file = 'a.xml'))
-  # a .txt is text/plain via mime_type()
-  (is_text_file(file = 'a.txt'))
-  (!is_text_file(file = 'a.png'))
+  # otherwise it falls back to the MIME type
+  (is_text_file('txt', 'text/plain', 'a.txt'))
+  (!is_text_file('png', 'image/png', 'a.png'))
 })
 
 assert('is_roaming() reflects the litedown.roaming option', {

--- a/tests/test-cran/test-preview.R
+++ b/tests/test-cran/test-preview.R
@@ -1,0 +1,110 @@
+library(testit)
+
+assert('is_lite_ext() recognizes extensions litedown can render', {
+  (is_lite_ext(file = 'a.Rmd'))
+  (is_lite_ext(file = 'a.md'))
+  (is_lite_ext(file = 'a.MD'))   # case-insensitive
+  (is_lite_ext(file = 'a.qmd'))
+  (is_lite_ext(file = 'a.r'))
+  (!is_lite_ext(file = 'a.png'))
+})
+
+assert('is_text_file() detects text files by extension or MIME type', {
+  (is_text_file(file = 'a.js'))
+  (is_text_file(file = 'a.tex'))
+  (is_text_file(file = 'a.xml'))
+  # a .txt is text/plain via mime_type()
+  (is_text_file(file = 'a.txt'))
+  (!is_text_file(file = 'a.png'))
+})
+
+assert('is_roaming() reflects the litedown.roaming option', {
+  (!is_roaming())
+  opt = options(litedown.roaming = TRUE)
+  (is_roaming())
+  options(opt)
+  (!is_roaming())
+})
+
+assert('file_raw() returns a raw file response with a content type', {
+  f = tempfile(fileext = '.txt'); writeLines('x', f)
+  on.exit(unlink(f), add = TRUE)
+  r = file_raw(f)
+  (same_path(r$file, f))
+  (r[['content-type']] %==% 'text/plain')
+})
+
+assert('file_size() and file_time() format file metadata', {
+  f = tempfile(); writeLines('hello', f)
+  on.exit(unlink(f), add = TRUE)
+  (grepl('bytes|KB|B', file_size(f)))
+  (is.character(file_time(f)))
+})
+
+assert('btn() builds a Markdown link with a .btn-lite class', {
+  # a plain label
+  (grepl('[Hi](<u>){.btn-lite}', btn('Hi', 'u'), fixed = TRUE))
+  # a dotted name maps to an icon and adds the name as a class
+  b = btn('.save')
+  (grepl('.btn-lite .save', b, fixed = TRUE))
+  (grepl(.icons[['.save']], b, fixed = TRUE))
+})
+
+assert('proj_info() classifies a directory as default, book, or site', {
+  d = tempfile(); dir.create(d)
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  f = file.path(d, 'a.md'); writeLines('x', f)
+  # no config -> default project, no root
+  pi = proj_info(f)
+  (pi$type %==% 'default')
+  (is.na(pi$root))
+  # a _litedown.yml with a 'book' field -> book project
+  writeLines(c('book:', '  new_session: false'), file.path(d, '_litedown.yml'))
+  pi2 = proj_info(file.path(d, 'index.md'))
+  (pi2$type %==% 'book')
+  (isTRUE(pi2$index))         # index.md at the root is the book index
+  (!is.na(pi2$root))
+})
+
+assert('dir_page() renders a directory listing to HTML', {
+  d = tempfile(); dir.create(d)
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  writeLines('# Hello', file.path(d, 'index.md'))
+  writeLines('x', file.path(d, 'notes.txt'))
+  p = as.character(dir_page(d))
+  (any(grepl('<', p)))          # HTML output
+  (any(grepl('index.md', p)))   # lists the files
+})
+
+assert('file_resp() sends raw, verbatim, or rendered responses by preview level', {
+  d = tempfile(); dir.create(d)
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  f = file.path(d, 'a.md'); writeLines('# Hi', f)
+  # preview 0: raw file response
+  (!is.null(file_resp(f, '0')$file))
+  # preview 1: verbatim (source shown in a code block), rendered to HTML
+  p1 = file_resp(f, '1')$payload
+  (!is.null(p1))
+  (any(grepl('<pre', p1)))
+  # preview 2: fully rendered markdown (heading becomes <h1>)
+  p2 = file_resp(f, '2')$payload
+  (any(grepl('<h1', p2)))
+})
+
+assert('file_page() injects navigation links at the top of a rendered page', {
+  d = tempfile(); dir.create(d)
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  f = file.path(d, 'a.md'); writeLines('# Hi', f)
+  r = file_page(f, '1')
+  (any(grepl('nav-path', r$payload)))
+})
+
+assert('lite_handler() dispatches directories and files', {
+  d = tempfile(); dir.create(d)
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  writeLines('# Hi', file.path(d, 'a.md'))
+  # a directory path yields a directory listing
+  (!is.null(lite_handler(d, list(), NULL, NULL)$payload))
+  # a file path yields a file response
+  (!is.null(lite_handler(file.path(d, 'a.md'), list(preview = '1'), NULL, NULL)$payload))
+})

--- a/tests/test-cran/test-render.R
+++ b/tests/test-cran/test-render.R
@@ -129,3 +129,11 @@ assert('prose_index() returns the lines that are not inside a code block', {
   # an element carrying an embedded newline still maps to a single index
   (pidx(c('a\nb', '```', 'x', '```')) %==% 1L)
 })
+
+assert('GFM extensions are inert unless explicitly enabled', {
+  # exact renderer output for enabled extensions is pinned in test-render.md;
+  # here we only check that the features stay off by default
+  (!grepl('<table', markdown_html('|a|b|\n|-|-|\n|1|2|\n')))
+  (!grepl('<del>', markdown_html('~~x~~\n')))
+  (!grepl('<a href', markdown_html('see https://x.com\n')))
+})

--- a/tests/test-cran/test-render.R
+++ b/tests/test-cran/test-render.R
@@ -108,26 +108,25 @@ assert('an opening code fence ends a preceding HTML block', {
 })
 
 assert('prose_index() returns the lines that are not inside a code block', {
-  pidx = getFromNamespace('prose_index', 'litedown')
   # plain prose: every line
-  (pidx(c('a', 'b', 'c')) %==% 1:3)
+  (prose_index(c('a', 'b', 'c')) %==% 1:3)
   # fenced code block: the fence and its body are excluded
-  (pidx(c('a', '```', 'x', '```', 'b')) %==% c(1L, 5L))
-  (pidx(c('a', '```r', 'x', '```', 'b')) %==% c(1L, 5L))
+  (prose_index(c('a', '```', 'x', '```', 'b')) %==% c(1L, 5L))
+  (prose_index(c('a', '```r', 'x', '```', 'b')) %==% c(1L, 5L))
   # a tilde fence is a code fence too
-  (pidx(c('a', '~~~', '```', '~~~', 'b')) %==% c(1L, 5L))
+  (prose_index(c('a', '~~~', '```', '~~~', 'b')) %==% c(1L, 5L))
   # indented (4-space) code blocks are excluded (xfun::prose_index missed these);
   # cmark includes the trailing blank line in the block, so line 4 is code too
-  (pidx(c('a', '', '    code', '', 'b')) %==% c(1L, 2L, 5L))
+  (prose_index(c('a', '', '    code', '', 'b')) %==% c(1L, 2L, 5L))
   # an unclosed fence runs to the end of the document (no all-prose fallback)
-  (pidx(c('a', '```', 'x')) %==% 1L)
+  (prose_index(c('a', '```', 'x')) %==% 1L)
   # raw HTML blocks remain prose (only code blocks are excluded)
-  (pidx(c('a', '<pre>', 'x', '</pre>', 'b')) %==% 1:5)
+  (prose_index(c('a', '<pre>', 'x', '</pre>', 'b')) %==% 1:5)
   # edge cases
-  (pidx(character(0)) %==% integer(0))
-  (pidx(c('```', 'x', '```')) %==% integer(0))
+  (prose_index(character(0)) %==% integer(0))
+  (prose_index(c('```', 'x', '```')) %==% integer(0))
   # an element carrying an embedded newline still maps to a single index
-  (pidx(c('a\nb', '```', 'x', '```')) %==% 1L)
+  (prose_index(c('a\nb', '```', 'x', '```')) %==% 1L)
 })
 
 assert('GFM extensions are inert unless explicitly enabled', {

--- a/tests/test-cran/test-render.md
+++ b/tests/test-cran/test-render.md
@@ -1,0 +1,219 @@
+# Snapshot tests for the C renderers and GFM/litedown extensions
+
+The renderers (`html.c`, `latex.c`, `plaintext.c`, `man.c`, `xml.c`) and the
+GFM/litedown extensions (`table.c`, `autolink.c`, `tagfilter.c`,
+`strikethrough.c`, `tasklist.c`) are only reachable through these entry points,
+so their exact output is pinned here.
+
+## GFM table to HTML (with column alignment)
+
+```r
+cat(markdown_html(c('|a|b|', '|:-|-:|', '|1|2|'), extensions = 'table'))
+```
+```
+<table>
+<thead>
+<tr>
+<th align="left">a</th>
+<th align="right">b</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="left">1</td>
+<td align="right">2</td>
+</tr>
+</tbody>
+</table>
+```
+
+## GFM table to LaTeX tabular
+
+```r
+cat(markdown_latex(c('|a|b|', '|:-|-:|', '|1|2|'), extensions = 'table'))
+```
+```
+\begin{table}
+\begin{tabular}{lr}
+a & b \\
+1 & 2 \\
+\end{tabular}
+\end{table}
+```
+
+## Autolink: URLs, www, and emails
+
+```r
+cat(markdown_html('see https://x.com, www.x.com, and me@x.com', extensions = 'autolink'))
+```
+```
+<p>see <a href="https://x.com">https://x.com</a>, <a href="http://www.x.com">www.x.com</a>, and <a href="mailto:me@x.com">me@x.com</a></p>
+```
+
+## Tagfilter neutralizes dangerous raw HTML tags
+
+```r
+cat(markdown_html(c('<script>alert(1)</script>', '', '<b>ok</b>'), extensions = 'tagfilter'))
+```
+```
+&lt;script>alert(1)&lt;/script>
+<p><b>ok</b></p>
+```
+
+## Strikethrough to HTML and LaTeX
+
+```r
+cat(markdown_html('~~x~~', extensions = 'strikethrough'))
+cat(markdown_latex('~~x~~', extensions = 'strikethrough'))
+```
+```
+<p><del>x</del></p>
+\sout{x}
+```
+
+## Task list checkboxes
+
+```r
+cat(markdown_html(c('- [x] done', '- [ ] todo'), extensions = 'tasklist'))
+```
+```
+<ul>
+<li><input type="checkbox" checked="" /> done</li>
+<li><input type="checkbox" /> todo</li>
+</ul>
+```
+
+## LaTeX: sectioning, lists, quote, code, and rule
+
+```r
+cat(markdown_latex(c(
+  '# h1', '', '## h2', '', '1. a', '2. b', '', '- x', '- y', '',
+  '> quote', '', '```', 'code', '```', '', '---'
+)))
+```
+```
+\section{h1}
+
+\subsection{h2}
+
+\begin{enumerate}
+\item a
+
+\item b
+
+\end{enumerate}
+
+\begin{itemize}
+\item x
+
+\item y
+
+\end{itemize}
+
+\begin{quote}
+quote
+
+\end{quote}
+
+\begin{verbatim}
+code
+\end{verbatim}
+
+\begin{center}\rule{0.5\linewidth}{\linethickness}\end{center}
+```
+
+## LaTeX escapes special characters
+
+```r
+cat(markdown_latex('100% a_b #c $d & e'))
+```
+```
+100\% a\_b \#c \$d \& e
+```
+
+## LaTeX: emphasis, strong, code, link, image
+
+```r
+cat(markdown_latex('*a* **b** `c` [t](http://u) ![alt](i.png)'))
+```
+```
+\emph{a} \textbf{b} \texttt{c} \href{http://u}{t} \protect\includegraphics{i.png}
+```
+
+## LaTeX: ordered list not starting at 1 sets the counter
+
+```r
+cat(markdown_latex(c('4. x', '5. y')))
+```
+```
+\begin{enumerate}
+\setcounter{enumi}{4}
+\item x
+
+\item y
+
+\end{enumerate}
+```
+
+## Plain-text renderer strips inline markup
+
+```r
+cat(markdown_text('# Hi *world* and `code`'))
+```
+```
+Hi world and code
+```
+
+## Man (roff) renderer
+
+```r
+cat(markdown_man(c('# Title', '', 'a *em* and **strong**', '', '- one', '- two')))
+```
+```
+.SH
+Title
+.PP
+a \f[I]em\f[] and \f[B]strong\f[]
+.IP \[bu] 2
+one
+.IP \[bu] 2
+two
+```
+
+## XML renderer emits a CommonMark document tree
+
+```r
+cat(markdown_xml('# Hi [t](u)'))
+```
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE document SYSTEM "CommonMark.dtd">
+<document xmlns="http://commonmark.org/xml/1.0">
+  <heading level="1">
+    <text xml:space="preserve">Hi </text>
+    <link destination="u" title="">
+      <text xml:space="preserve">t</text>
+    </link>
+  </heading>
+</document>
+```
+
+## Commonmark renderer normalizes Markdown
+
+```r
+cat(markdown_commonmark(c('#   Hi', '', '_a_ and **b**')))
+```
+```
+# Hi
+
+*a* and **b**
+```
+
+## HTML escapes metacharacters in text
+
+```r
+cat(markdown_html('a < b & c > d'))
+```
+```
+<p>a &lt; b &amp; c &gt; d</p>
+```

--- a/tests/test-cran/test-site.R
+++ b/tests/test-cran/test-site.R
@@ -49,11 +49,11 @@ assert('find_input() drops a .md file shadowed by a same-stem .Rmd', {
 
 assert('filter_outdated() flags inputs whose output is missing or stale', {
   f1 = tempfile(); f2 = tempfile()
-  writeLines('a', f1); Sys.sleep(1.05); writeLines('b', f2)
+  writeLines('a', f1); Sys.sleep(.05); writeLines('b', f2)
   # output (f2) is newer than input (f1) -> not outdated
   (isFALSE(filter_outdated(f1, f2, 0)))
   # output newer than input (f1) but input rewritten later -> outdated
-  Sys.sleep(1.05); writeLines('a2', f1)
+  Sys.sleep(.05); writeLines('a2', f1)
   (isTRUE(filter_outdated(f1, f2, 0)))
   # a missing output is always outdated
   (isTRUE(filter_outdated(f1, tempfile(), 0)))

--- a/tests/test-cran/test-site.R
+++ b/tests/test-cran/test-site.R
@@ -1,0 +1,98 @@
+library(testit)
+
+assert('menu_name() turns a filename stem into a title', {
+  (menu_name('about-us') %==% 'About Us')
+  (menu_name('my_page') %==% 'My Page')
+})
+
+assert('is_index() detects an index file regardless of directory/extension', {
+  (is_index('index.Rmd'))
+  (is_index('a/b/index.md'))
+  (!is_index('a/foo.md'))
+})
+
+assert('reorder_input() puts the index file first', {
+  (basename(reorder_input(c('a/b.md', 'a/index.md'))) %==% c('index.md', 'b.md'))
+  # the shortest index path wins when several exist
+  x = reorder_input(c('sub/index.md', 'index.md', 'z.md'))
+  (basename(x[1]) %==% 'index.md')
+  (x[1] %==% 'index.md')
+})
+
+assert('find_input() lists input files, excluding hidden/underscore/readme', {
+  d = tempfile(); dir.create(d)
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  writeLines('x', file.path(d, 'index.Rmd'))
+  writeLines('y', file.path(d, 'about.md'))
+  writeLines('z', file.path(d, '_draft.Rmd'))    # underscore -> excluded
+  writeLines('r', file.path(d, 'README.md'))      # readme -> excluded
+  b = basename(find_input(d))
+  ('index.Rmd' %in% b)
+  ('about.md' %in% b)
+  (!('_draft.Rmd' %in% b))
+  (!('README.md' %in% b))
+  # index comes first
+  (b[1] %==% 'index.Rmd')
+})
+
+assert('find_input() drops a .md file shadowed by a same-stem .Rmd', {
+  d = tempfile(); dir.create(d)
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  writeLines('a', file.path(d, 'foo.Rmd'))
+  writeLines('b', file.path(d, 'foo.md'))   # shadowed by foo.Rmd -> excluded
+  writeLines('c', file.path(d, 'bar.md'))   # kept (no bar.Rmd)
+  b = basename(find_input(d))
+  ('foo.Rmd' %in% b)
+  (!('foo.md' %in% b))
+  ('bar.md' %in% b)
+})
+
+assert('filter_outdated() flags inputs whose output is missing or stale', {
+  f1 = tempfile(); f2 = tempfile()
+  writeLines('a', f1); Sys.sleep(1.05); writeLines('b', f2)
+  # output (f2) is newer than input (f1) -> not outdated
+  (isFALSE(filter_outdated(f1, f2, 0)))
+  # output newer than input (f1) but input rewritten later -> outdated
+  Sys.sleep(1.05); writeLines('a2', f1)
+  (isTRUE(filter_outdated(f1, f2, 0)))
+  # a missing output is always outdated
+  (isTRUE(filter_outdated(f1, tempfile(), 0)))
+  unlink(c(f1, f2))
+})
+
+assert('yml_config() reads and normalizes _litedown.yml', {
+  d = tempfile(); dir.create(d)
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  # no config -> NULL
+  (is.null(yml_config(d)))
+  writeLines(c('output:', '  html_document:', '    toc: true'),
+             file.path(d, '_litedown.yml'))
+  y = yml_config(d)
+  # html_document is normalized to the litedown 'html' format
+  (names(y$output) %==% 'html')
+})
+
+# end-to-end: build the bundled site/book skeletons
+
+assert('fuse_site() renders every input file in a site skeleton to HTML', {
+  d = tempfile()
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  proj_skeleton(d, 'site')
+  out = fuse_site(d)
+  (all(file_exists(out)))
+  (file_exists(file.path(d, 'index.html')))
+  # the rendered index is non-empty HTML
+  (length(readLines(file.path(d, 'index.html'))) > 0L)
+})
+
+assert('fuse_book() renders a book skeleton into a single HTML file', {
+  d = tempfile()
+  on.exit(unlink(d, recursive = TRUE), add = TRUE)
+  proj_skeleton(d, 'book')
+  out = fuse_book(d)
+  (file_exists(out))
+  (basename(out) %==% 'index.html')
+  h = readLines(out)
+  # chapters are wrapped in .chapter divs
+  (any(grepl('class="chapter', h, fixed = TRUE)))
+})

--- a/tests/test-cran/test-utils.R
+++ b/tests/test-cran/test-utils.R
@@ -61,3 +61,160 @@ assert('locale_lang() returns a BCP 47 language tag string', {
   # either empty or a valid BCP 47 tag (letters, possibly with a hyphen and region)
   (nchar(lang) == 0L || grepl('^[a-z]{2,3}(-[A-Z]{2,3})?$', lang))
 })
+
+assert('sans_p() strips a wrapping <p> tag and trailing newline', {
+  (sans_p('<p>hi</p>\n') %==% 'hi')
+  # a <p> with attributes is stripped too
+  (sans_p('<p class="x">a</p>\n') %==% 'a')
+  # an opening <p> with no closing tag still loses the tag and newline
+  (sans_p('<p>abc\n') %==% 'abc')
+})
+
+assert("sans_sq() removes single quotes around words", {
+  (sans_sq("use 'R' and 'knitr' here") %==% 'use R and knitr here')
+  # quotes not surrounding a bare word are left alone
+  (sans_sq("it's fine") %==% "it's fine")
+})
+
+assert('str_trim() and trim_blank() trim whitespace', {
+  (str_trim('  hi  ') %==% 'hi')
+  (str_trim('\tx\n') %==% 'x')
+  # trim_blank removes blank lines from both ends but keeps inner content
+  (trim_blank('\n\n  x\n  \n') %==% '  x')
+})
+
+assert('comma_list() quotes and comma-joins its input', {
+  (comma_list(c('a', 'b', 'c')) %==% '"a", "b", "c"')
+  (comma_list('a') %==% '"a"')
+})
+
+assert('one_string() collapses a vector with a separator', {
+  (one_string(c('a', 'b')) %==% 'a\nb')          # default newline
+  (one_string(c('a', 'b'), ' ') %==% 'a b')
+})
+
+assert('is_ext() detects a bare file extension', {
+  (is_ext('.md'))
+  (is_ext('.html'))
+  (!is_ext('foo.md'))   # has a base name
+  (!is_ext('md'))       # no leading dot
+})
+
+assert('has_class() detects a class token in an HTML attribute string', {
+  (has_class('<div class="a b c">', 'b'))
+  (has_class('<div class="a">', 'a'))
+  (!has_class('<div class="a">', 'b'))
+  # a partial match must not count (foobar is not the class foo)
+  (!has_class('<div class="foobar">', 'foo'))
+})
+
+assert('unique_id() disambiguates duplicated ids and fills empties', {
+  (unique_id(c('a', 'a', 'b'), 'sec') %==% c('a_1', 'a_2', 'b'))
+  # empty strings are replaced with the fallback first
+  (unique_id(c('', 'x'), 'sec') %==% c('sec', 'x'))
+  (unique_id(c('', ''), 'sec') %==% c('sec_1', 'sec_2'))
+})
+
+assert('merge_list() overrides earlier values and appends new keys', {
+  (merge_list(list(a = 1, b = 2), list(b = 3, c = 4)) %==% list(a = 1, b = 3, c = 4))
+})
+
+assert('na_omit() and dropNULL() drop missing/NULL elements', {
+  (na_omit(c(1, NA, 3)) %==% c(1, 3))
+  (dropNULL(list(a = 1, b = NULL, c = 3)) %==% list(a = 1, c = 3))
+})
+
+assert('set_names() assigns names to a vector', {
+  (set_names(1:2, c('x', 'y')) %==% c(x = 1L, y = 2L))
+})
+
+assert('named_bool() builds a named logical list', {
+  (named_bool(c('a', 'b')) %==% list(a = TRUE, b = TRUE))
+  (named_bool('a', FALSE) %==% list(a = FALSE))
+})
+
+assert('redefine_level() raises LaTeX sectioning levels', {
+  (redefine_level('\\section{x}', 'chapter') %==% '\\chapter{x}')
+  (redefine_level('\\section{x}', 'part') %==% '\\part{x}')
+  (redefine_level('\\subsection{x}', 'chapter') %==% '\\section{x}')
+  # top = 'section' (or anything but chapter/part) is a no-op
+  (redefine_level('\\section{x}', 'section') %==% '\\section{x}')
+})
+
+assert('latex_envir() turns a nesting spec into begin/end pairs', {
+  # {A}, '', ... closes the most recent environment on an empty entry
+  (latex_envir(c('{A}', '')) %==% c('\\begin{A}', '\\end{A}'))
+  (latex_envir(c('{A}', '{B}', '', '')) %==%
+     c('\\begin{A}', '\\begin{B}', '\\end{B}', '\\end{A}'))
+})
+
+assert('sub_var() substitutes the first matching variable name in a template', {
+  (sub_var('a $x$ b', '$x$', 'Y') %==% 'a Y b')
+  # the first name present wins; a missing earlier name is skipped
+  (sub_var('a NAME b', c('MISSING', 'NAME'), 'Z') %==% 'a Z b')
+  # no match leaves the template unchanged
+  (sub_var('nothing here', 'ABSENT', 'Z') %==% 'nothing here')
+})
+
+assert('match_full() returns whole matches split by line', {
+  (match_full('a1 b2 c3', '[a-z][0-9]') %==% c('a1', 'b2', 'c3'))
+})
+
+assert('match_all() returns a matrix of full match plus capture groups', {
+  m = match_all('k1=v1 k2=v2', '([a-z0-9]+)=([a-z0-9]+)')
+  (m[1, ] %==% c('k1=v1', 'k2=v2'))
+  (m[2, ] %==% c('k1', 'k2'))
+  (m[3, ] %==% c('v1', 'v2'))
+})
+
+assert('match_one() captures groups from a single match', {
+  (match_one('k=v', '([a-z]+)=([a-z]+)')[[1]] %==% c('k=v', 'k', 'v'))
+})
+
+assert('is_output_file() recognizes a real output path (not a format/ext)', {
+  (is_output_file('foo.html'))
+  (!is_output_file('html'))   # a known format name
+  (!is_output_file('.md'))    # a bare extension
+})
+
+assert('is_output_full() reads the full attribute', {
+  (is_output_full(structure('x', full = TRUE)))
+  (!is_output_full('x'))
+})
+
+assert('auto_output() derives an output name from format or extension', {
+  # NULL output + a format -> the format's default extension (named by format)
+  (unname(auto_output(I('txt'), NULL, 'html')) %==% '.html')
+  # an unsupported format errors
+  (has_error(auto_output(I('x'), NULL, 'bogus')))
+  # a bare extension + a file input -> input path with that extension
+  (auto_output('in.Rmd', '.html') %==% 'in.html')
+})
+
+assert('auto_identifier() adds ids to headings and keeps existing ones', {
+  (auto_identifier('<h2>Hello World</h2>') %==% '<h2 id="sec:hello-world">Hello World</h2>')
+  # h1 gets a chp: prefix; h2+ get sec:
+  (auto_identifier('<h1>Intro</h1>') %==% '<h1 id="chp:intro">Intro</h1>')
+  # a heading that already has an id is left untouched
+  (auto_identifier('<h2 id="x">Y</h2>') %==% '<h2 id="x">Y</h2>')
+})
+
+assert('build_toc() builds a nested TOC from HTML headings', {
+  toc = build_toc(c('<h1 id="a">A</h1>', '<h2 id="b">B</h2>'))
+  (grepl('id="TOC"', toc, fixed = TRUE))
+  (grepl('<a href="#a">A</a>', toc, fixed = TRUE))
+  (grepl('<a href="#b">B</a>', toc, fixed = TRUE))
+  # headings marked class="unlisted" are excluded, dropping the TOC below 2 items
+  (is.null(build_toc(c('<h1 id="a">A</h1>', '<h2 id="b" class="unlisted">B</h2>'))))
+  # n <= 0 disables the TOC
+  (is.null(build_toc(c('<h1 id="a">A</h1>', '<h2 id="b">B</h2>'), 0)))
+})
+
+assert('number_sections() prefixes hierarchical numbers to HTML headings', {
+  x = number_sections(c('<h1>A</h1>', '<h2>B</h2>', '<h1>C</h1>'))
+  (grepl('main-number">1</span> A', x, fixed = TRUE))
+  (grepl('section-number">1.1</span> B', x, fixed = TRUE))
+  (grepl('main-number">2</span> C', x, fixed = TRUE))
+  # input with no headings is returned unchanged
+  (number_sections('<p>no heading</p>') %==% '<p>no heading</p>')
+})


### PR DESCRIPTION
## Summary

Raises R-code line coverage from ~38% to ~62% and adds tests that exercise the bundled cmark-gfm C renderers and extensions, which were previously largely untested.

## New test files

- **test-format.R** — YAML normalization and output-format detection (`normalize_yaml`, `detect_format`, `yaml_format`/`yaml_field`, `map_args`).
- **test-package.R** — package-documentation helpers (`pkg_desc`, `pkg_news`, `pkg_citation`, `pkg_manual`, `header_class`, `pkg_authors`, `tweak_citation`, `detect_news`, `Rd_aliases`). Rd-based tests are gated on a help DB being available, since `test_pkg()`'s fast install has none.
- **test-site.R** — site/book helpers (`find_input`, `reorder_input`, `is_index`, `menu_name`, `filter_outdated`, `yml_config`) plus end-to-end `fuse_site()`/`fuse_book()` builds of the bundled skeletons.
- **test-preview.R** — `roam()` request handling (`lite_handler`, `file_resp`, `file_page`, `dir_page`, `proj_info`, `btn`, `is_lite_ext`, `is_text_file`, `file_raw`).
- **test-render.md** — snapshot tests pinning the exact output of the C renderers (`html`/`latex`/`plaintext`/`man`/`xml`) and GFM/litedown extensions (`table`, `autolink`, `tagfilter`, `strikethrough`, `tasklist`).

## Extended existing files

- **test-utils.R** — string/attribute/regex helpers, `auto_identifier`, `build_toc`, `number_sections`, `redefine_level`, `latex_envir`, etc.
- **test-fuse.R** — chunk options (echo/eval/error/results/collapse/comment), inline evaluation and numeric formatting, custom engines, `raw_text()`.
- **test-render.R** — AST unit tests kept; the renderer output greps were moved into the `test-render.md` snapshot, leaving a small negative check that extensions stay off by default.

## Testing

`testit::test_pkg("litedown", "test-cran")` and `test-ci` both pass.