### PR TITLE
Support numeric line numbers in the chunk option `echo` (#93)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # CHANGES IN litedown VERSION 0.12
 
+- The chunk option `echo` can now take a numeric vector of line numbers to select which lines of the source code to display, e.g., `echo = -1` hides the first line, and `echo = 2:3` shows only the second and third lines (thanks, @jangorecki, #93).
+
 - The Markdown backend has been changed from the **commonmark** package to a copy of 'cmark-gfm' bundled with **litedown**, with our own patches and extensions. Features that used to be emulated with fragile text processing in R (LaTeX math, superscript/subscript/strikethrough, raw content blocks, and inline attributes on links and images) are now handled directly by the Markdown parser, which is faster and more reliable, especially for large documents and documents with multibyte (e.g., CJK) characters. This also fixes several long-standing rendering bugs (#33, #135, #139). The **commonmark** package is no longer a dependency (#141, #142, #143). Rendering output is essentially unchanged, with one minor exception: superscript, subscript, and strikethrough now require the delimiters to "hug" their content (e.g., `a^b^` works, but `a ^ b ^` no longer produces a superscript), consistent with how `*emphasis*` works.
 
 # CHANGES IN litedown VERSION 0.11

--- a/R/fuse.R
+++ b/R/fuse.R
@@ -818,8 +818,14 @@ fuse_code = function(x, blocks) {
     type = grep_sub('^record_', '', class(x))[1]
     if (is.na(type)) type = 'output'
     if (type == 'source') {
-      if (!opts$echo) return()
       l2 = attr(x, 'lines')[1]  # starting line number of a code block
+      # `echo` can be a logical value or a numeric vector of line numbers to
+      # include (positive) or exclude (negative) from the source
+      if (is.numeric(e <- opts$echo)) {
+        idx = l2 + seq_along(x) - 1L  # line number of each source line
+        x = x[if (any(e < 0)) !(idx %in% -e) else idx %in% e]
+        if (length(x) == 0) return()
+      } else if (!e) return()
       x = one_string(x)
       if (opts$strip.white) x = trim_blank(x)
     }

--- a/docs/02-fuse.Rmd
+++ b/docs/02-fuse.Rmd
@@ -673,6 +673,21 @@ By default, the source code blocks are displayed in the output with the chunk
 option `echo = TRUE`. To suppress source code blocks, you can use
 `echo = FALSE`.
 
+The `echo` option can also take a numeric vector of line numbers to select which
+lines of the source code to display. Positive numbers indicate the lines to
+include, and negative numbers indicate the lines to exclude. For example,
+`echo = -1` hides the first line of the source code, which can be useful when a
+line is not interesting to readers, e.g., a `set.seed()` call:
+
+```{{r, echo = -1}}
+set.seed(108)
+rnorm(3)
+```
+
+Similarly, `echo = 2:3` shows only the second and third lines. The line numbers
+are relative to the whole code chunk (counting from 1), and out-of-range numbers
+are ignored.
+
 ### `error`: error behavior {#sec:option-error}
 
 You can specify how errors in a code chunk should be handled with the `error`

--- a/tests/test-cran/test-fuse.R
+++ b/tests/test-cran/test-fuse.R
@@ -21,21 +21,6 @@ assert('code blocks after asis HTML output are rendered correctly (regression)',
   (as.character(gsub('.*<pre><code class="language-r">1:2.*', '', out)) %==% '')
 })
 
-assert('fuse() echo option selects source lines by number (#93)', {
-  src = c('```{r}', 'a = 1', 'b = 2', 'c = 3', '```')
-  # negative numbers exclude lines
-  out = one_string(fuse(text = sub('r', 'r, echo = -1', src, fixed = TRUE), output = 'markdown'))
-  (!grepl('a = 1', out, fixed = TRUE))
-  (grepl('b = 2', out, fixed = TRUE) && grepl('c = 3', out, fixed = TRUE))
-  # positive numbers include only those lines
-  out = one_string(fuse(text = sub('r', 'r, echo = c(1, 3)', src, fixed = TRUE), output = 'markdown'))
-  (grepl('a = 1', out, fixed = TRUE) && grepl('c = 3', out, fixed = TRUE))
-  (!grepl('b = 2', out, fixed = TRUE))
-  # echo = FALSE still hides all source
-  out = one_string(fuse(text = sub('r', 'r, echo = FALSE', src, fixed = TRUE), output = 'markdown'))
-  (!grepl('a = 1', out, fixed = TRUE))
-})
-
 assert('fuse() fig.path option controls plot file location', {
   src = c(
     '---', 'output:', '  html:', '    options:', '      embed_resources: false',

--- a/tests/test-cran/test-fuse.R
+++ b/tests/test-cran/test-fuse.R
@@ -21,6 +21,21 @@ assert('code blocks after asis HTML output are rendered correctly (regression)',
   (as.character(gsub('.*<pre><code class="language-r">1:2.*', '', out)) %==% '')
 })
 
+assert('fuse() echo option selects source lines by number (#93)', {
+  src = c('```{r}', 'a = 1', 'b = 2', 'c = 3', '```')
+  # negative numbers exclude lines
+  out = one_string(fuse(text = sub('r', 'r, echo = -1', src, fixed = TRUE), output = 'markdown'))
+  (!grepl('a = 1', out, fixed = TRUE))
+  (grepl('b = 2', out, fixed = TRUE) && grepl('c = 3', out, fixed = TRUE))
+  # positive numbers include only those lines
+  out = one_string(fuse(text = sub('r', 'r, echo = c(1, 3)', src, fixed = TRUE), output = 'markdown'))
+  (grepl('a = 1', out, fixed = TRUE) && grepl('c = 3', out, fixed = TRUE))
+  (!grepl('b = 2', out, fixed = TRUE))
+  # echo = FALSE still hides all source
+  out = one_string(fuse(text = sub('r', 'r, echo = FALSE', src, fixed = TRUE), output = 'markdown'))
+  (!grepl('a = 1', out, fixed = TRUE))
+})
+
 assert('fuse() fig.path option controls plot file location', {
   src = c(
     '---', 'output:', '  html:', '    options:', '      embed_resources: false',

--- a/tests/test-cran/test-fuse.md
+++ b/tests/test-cran/test-fuse.md
@@ -36,6 +36,30 @@ fuse(text = c('```{r, echo=FALSE}', '2 * 3', '```'), output = 'markdown')
 ```
 `````
 
+## echo = -1 hides the first source line (#93)
+
+`````r
+fuse(text = c('```{r, echo=-1}', 'a = 1', 'b = 2', 'c = 3', '```'), output = 'markdown')
+`````
+`````
+``` {.r}
+b = 2
+c = 3
+```
+`````
+
+## echo = c(1, 3) shows only the selected source lines (#93)
+
+`````r
+fuse(text = c('```{r, echo=c(1, 3)}', 'a = 1', 'b = 2', 'c = 3', '```'), output = 'markdown')
+`````
+`````
+``` {.r}
+a = 1
+c = 3
+```
+`````
+
 ## eval = FALSE doesn't run code
 
 `````r


### PR DESCRIPTION
Closes #93.

## What

The `echo` chunk option now accepts a numeric vector of line numbers in addition to a logical value:

- Positive numbers select which lines of the source code to display, e.g., `echo = 2:3` shows only the second and third lines.
- Negative numbers select lines to exclude, e.g., `echo = -1` hides the first line — useful for hiding uninteresting lines such as a `set.seed()` call, as requested in the issue.

Line numbers are relative to the whole code chunk (counting from 1), and out-of-range numbers are ignored. Line numbering is preserved correctly even when a chunk's source is split into multiple blocks by interleaved output.

## Changes

- `R/fuse.R`: extend the `source` record handler to filter lines when `echo` is numeric.
- `docs/02-fuse.Rmd`: document the new behavior under the `echo` option section.
- `NEWS.md`: add a changelog entry.
- `tests/test-cran/test-fuse.R`: add a test covering positive, negative, and `FALSE` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)